### PR TITLE
handle single-element anyOf/allOf/oneOf

### DIFF
--- a/src/context.rs
+++ b/src/context.rs
@@ -47,7 +47,7 @@ impl<'a> Context<'a> {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, Debug)]
 pub struct Contextual<'a, T> {
     context: Context<'a>,
     value: T,

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -1,5 +1,7 @@
 // Copyright 2025 Oxide Computer Company
 
+use std::fmt;
+
 use openapiv3::{AdditionalProperties, ArrayType, ObjectType, ReferenceOr, Schema, SchemaData};
 
 use crate::{
@@ -42,13 +44,128 @@ impl Compare {
         old_schema: Contextual<'_, &ReferenceOr<Schema>>,
         new_schema: Contextual<'_, &ReferenceOr<Schema>>,
     ) -> anyhow::Result<bool> {
-        let (old_schema, old_context) = old_schema.contextual_resolve()?;
-        let (new_schema, new_context) = new_schema.contextual_resolve()?;
+        // Handle single-element wrapper equivalence (allOf/anyOf/oneOf with one
+        // item). These are semantically equivalent to their inner type.
+        if let Some(result) =
+            self.try_compare_unwrapped(dry_run, comparison, &old_schema, &new_schema)?
+        {
+            Ok(result)
+        } else {
+            // Normal path: resolve and compare.
+            let (old_schema, old_context) = old_schema.contextual_resolve()?;
+            let (new_schema, new_context) = new_schema.contextual_resolve()?;
 
-        let old_schema = Contextual::new(old_context, old_schema.as_ref());
-        let new_schema = Contextual::new(new_context, new_schema.as_ref());
+            let old_schema = Contextual::new(old_context, old_schema.as_ref());
+            let new_schema = Contextual::new(new_context, new_schema.as_ref());
 
-        self.compare_schema(comparison, dry_run, old_schema, new_schema)
+            self.compare_schema(comparison, dry_run, old_schema, new_schema)
+        }
+    }
+
+    /// Try to compare schemas by unwrapping single-element wrappers.
+    ///
+    /// Returns `Some(result)` if unwrapping was applicable, `None` to fall
+    /// through.
+    fn try_compare_unwrapped(
+        &mut self,
+        dry_run: bool,
+        comparison: SchemaComparison,
+        old_schema: &Contextual<'_, &ReferenceOr<Schema>>,
+        new_schema: &Contextual<'_, &ReferenceOr<Schema>>,
+    ) -> anyhow::Result<Option<bool>> {
+        use SchemaRefKind::*;
+
+        let old_kind = classify_schema_ref(old_schema.as_ref());
+        let new_kind = classify_schema_ref(new_schema.as_ref());
+
+        match (old_kind, new_kind) {
+            // Both are single-element wrappers. Compare metadata and recurse
+            (
+                SingleElement {
+                    inner: old_inner,
+                    metadata: old_meta,
+                },
+                SingleElement {
+                    inner: new_inner,
+                    metadata: new_meta,
+                },
+            ) => {
+                if old_meta != new_meta {
+                    self.push_change(
+                        "schema metadata changed",
+                        old_schema,
+                        new_schema,
+                        comparison.into(),
+                        ChangeClass::Trivial,
+                        ChangeDetails::Metadata,
+                    );
+                }
+                let old_inner = old_schema.append_deref(old_inner, "0");
+                let new_inner = new_schema.append_deref(new_inner, "0");
+                Ok(Some(self.compare_schema_ref_helper(
+                    dry_run, comparison, old_inner, new_inner,
+                )?))
+            }
+            // Old is single-element wrapper, new is bare ref.
+            (
+                SingleElement {
+                    inner: old_inner,
+                    metadata: old_meta,
+                },
+                BareRef,
+            ) => {
+                if has_meaningful_metadata(old_meta) {
+                    self.push_change(
+                        "schema metadata changed",
+                        old_schema,
+                        new_schema,
+                        comparison.into(),
+                        ChangeClass::Trivial,
+                        ChangeDetails::Metadata,
+                    );
+                }
+                let old_inner = old_schema.append_deref(old_inner, "0");
+                Ok(Some(self.compare_schema_ref_helper(
+                    dry_run,
+                    comparison,
+                    old_inner,
+                    new_schema.clone(),
+                )?))
+            }
+            // Old is bare ref, new is single-element wrapper.
+            (
+                BareRef,
+                SingleElement {
+                    inner: new_inner,
+                    metadata: new_meta,
+                },
+            ) => {
+                if has_meaningful_metadata(new_meta) {
+                    self.push_change(
+                        "schema metadata changed",
+                        old_schema,
+                        new_schema,
+                        comparison.into(),
+                        ChangeClass::Trivial,
+                        ChangeDetails::Metadata,
+                    );
+                }
+                let new_inner = new_schema.append_deref(new_inner, "0");
+                Ok(Some(self.compare_schema_ref_helper(
+                    dry_run,
+                    comparison,
+                    old_schema.clone(),
+                    new_inner,
+                )?))
+            }
+            // No unwrapping applicable - fall through to normal comparison.
+            (BareRef, BareRef)
+            | (BareRef, Other)
+            | (Other, BareRef)
+            | (Other, Other)
+            | (SingleElement { .. }, Other)
+            | (Other, SingleElement { .. }) => Ok(None),
+        }
     }
 
     fn compare_schema(
@@ -244,15 +361,19 @@ impl Compare {
                     )
                 }
             }
-            _ => self.schema_push_change(
-                dry_run,
-                "schema kinds changed".to_string(),
-                &old_schema_kind,
-                &new_schema_kind,
-                comparison,
-                ChangeClass::Incompatible,
-                ChangeDetails::Datatype,
-            ),
+            _ => {
+                let old_tag = SchemaKindTag::new(&old_schema_kind);
+                let new_tag = SchemaKindTag::new(&new_schema_kind);
+                self.schema_push_change(
+                    dry_run,
+                    format!("schema kind changed from {} to {}", old_tag, new_tag),
+                    &old_schema_kind,
+                    &new_schema_kind,
+                    comparison,
+                    ChangeClass::Incompatible,
+                    ChangeDetails::Datatype,
+                )
+            }
         }
     }
 
@@ -667,4 +788,93 @@ impl Compare {
         }
         Ok(false)
     }
+}
+
+#[derive(Clone, Debug)]
+enum SchemaKindTag {
+    Type,
+    OneOf,
+    AllOf,
+    AnyOf,
+    Not,
+    Any,
+}
+
+impl fmt::Display for SchemaKindTag {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Type => write!(f, "regular type"),
+            Self::OneOf => write!(f, "oneOf"),
+            Self::AllOf => write!(f, "allOf"),
+            Self::AnyOf => write!(f, "anyOf"),
+            Self::Not => write!(f, "not"),
+            Self::Any => write!(f, "any"),
+        }
+    }
+}
+
+impl SchemaKindTag {
+    fn new(kind: &openapiv3::SchemaKind) -> Self {
+        match kind {
+            openapiv3::SchemaKind::Type(_) => Self::Type,
+            openapiv3::SchemaKind::OneOf { .. } => Self::OneOf,
+            openapiv3::SchemaKind::AllOf { .. } => Self::AllOf,
+            openapiv3::SchemaKind::AnyOf { .. } => Self::AnyOf,
+            openapiv3::SchemaKind::Not { .. } => Self::Not,
+            openapiv3::SchemaKind::Any { .. } => Self::Any,
+        }
+    }
+}
+
+/// Classification of a schema reference for wrapper unwrapping purposes.
+enum SchemaRefKind<'a> {
+    /// A bare $ref - can be compared with single-element wrappers.
+    BareRef,
+    /// A single-element allOf/anyOf/oneOf wrapper, semantically equivalent to
+    /// the inner type.
+    SingleElement {
+        inner: &'a ReferenceOr<Schema>,
+        metadata: &'a SchemaData,
+    },
+    /// Something else (multi-element wrapper or non-wrapper type).
+    Other,
+}
+
+/// Classify a schema reference for wrapper unwrapping purposes.
+fn classify_schema_ref(schema_ref: &ReferenceOr<Schema>) -> SchemaRefKind<'_> {
+    match schema_ref {
+        ReferenceOr::Reference { .. } => SchemaRefKind::BareRef,
+        ReferenceOr::Item(schema) => match &schema.schema_kind {
+            openapiv3::SchemaKind::AllOf { all_of } if all_of.len() == 1 => {
+                SchemaRefKind::SingleElement {
+                    inner: all_of.first().unwrap(),
+                    metadata: &schema.schema_data,
+                }
+            }
+            openapiv3::SchemaKind::AnyOf { any_of } if any_of.len() == 1 => {
+                SchemaRefKind::SingleElement {
+                    inner: any_of.first().unwrap(),
+                    metadata: &schema.schema_data,
+                }
+            }
+            openapiv3::SchemaKind::OneOf { one_of } if one_of.len() == 1 => {
+                SchemaRefKind::SingleElement {
+                    inner: one_of.first().unwrap(),
+                    metadata: &schema.schema_data,
+                }
+            }
+            openapiv3::SchemaKind::AllOf { .. }
+            | openapiv3::SchemaKind::AnyOf { .. }
+            | openapiv3::SchemaKind::OneOf { .. }
+            | openapiv3::SchemaKind::Type(_)
+            | openapiv3::SchemaKind::Not { .. }
+            | openapiv3::SchemaKind::Any(_) => SchemaRefKind::Other,
+        },
+    }
+}
+
+/// Check if schema_data has any non-default values that would constitute
+/// metadata worth preserving.
+fn has_meaningful_metadata(data: &SchemaData) -> bool {
+    *data != SchemaData::default()
 }

--- a/src/schema.rs
+++ b/src/schema.rs
@@ -118,9 +118,12 @@ impl Compare {
             ) => {
                 // Old is a single-element wrapper, new is a bare ref or inline
                 // type.
+                //
+                // A bare ref or inline type does not have metadata, so if the
+                // old metadata is non-default, report a trivial change.
                 if has_meaningful_metadata(old_meta) {
                     self.push_change(
-                        "schema metadata changed",
+                        "schema metadata removed",
                         old_schema,
                         new_schema,
                         comparison.into(),
@@ -145,9 +148,12 @@ impl Compare {
             ) => {
                 // Old is a bare ref or inline type, new is a single-element
                 // wrapper.
+                //
+                // A bare ref or inline type does not have metadata, so if the
+                // new metadata is non-default, report a trivial change.
                 if has_meaningful_metadata(new_meta) {
                     self.push_change(
-                        "schema metadata changed",
+                        "schema metadata added",
                         old_schema,
                         new_schema,
                         comparison.into(),
@@ -836,7 +842,8 @@ enum SchemaRefKind<'a> {
         inner: &'a ReferenceOr<Schema>,
         metadata: &'a SchemaData,
     },
-    /// Multi-element allOf/anyOf/oneOf: cannot be flattened.
+    /// Multi (or, less commonly, zero) element allOf/anyOf/oneOf: cannot be
+    /// flattened.
     MultiElement,
 }
 

--- a/tests/cases/simple/base.json
+++ b/tests/cases/simple/base.json
@@ -80,11 +80,46 @@
           "message": {
             "type": "string",
             "description": "The greeting message"
+          },
+          "via_ref": {
+            "$ref": "#/components/schemas/SubType"
+          },
+          "via_allof": {
+            "description": "Via allOf.",
+            "allOf": [
+              {
+                "$ref": "#/components/schemas/SubType"
+              }
+            ]
+          },
+          "via_anyof": {
+            "description": "Via anyOf.",
+            "anyOf": [
+              {
+                "$ref": "#/components/schemas/SubType"
+              }
+            ]
+          },
+          "via_oneof": {
+            "description": "Via oneOf.",
+            "oneOf": [
+              {
+                "$ref": "#/components/schemas/SubType"
+              }
+            ]
           }
         },
         "required": [
           "message"
         ]
+      },
+      "SubType": {
+        "type": "object",
+        "properties": {
+          "value": {
+            "type": "string"
+          }
+        }
       },
       "Tree": {
         "type": "object",

--- a/tests/cases/simple/base.json
+++ b/tests/cases/simple/base.json
@@ -107,6 +107,11 @@
                 "$ref": "#/components/schemas/SubType"
               }
             ]
+          },
+          "not_a_number": {
+            "not": {
+              "type": "number"
+            }
           }
         },
         "required": [

--- a/tests/cases/simple/output/add-operation.out
+++ b/tests/cases/simple/output/add-operation.out
@@ -1,6 +1,6 @@
 --- add-operation.json
 +++ patched
-@@ -33,6 +33,16 @@
+@@ -68,6 +68,16 @@
    },
    "openapi": "3.0.0",
    "paths": {

--- a/tests/cases/simple/output/add-operation.out
+++ b/tests/cases/simple/output/add-operation.out
@@ -1,6 +1,6 @@
 --- add-operation.json
 +++ patched
-@@ -68,6 +68,16 @@
+@@ -73,6 +73,16 @@
    },
    "openapi": "3.0.0",
    "paths": {

--- a/tests/cases/simple/output/add-type-extension.out
+++ b/tests/cases/simple/output/add-type-extension.out
@@ -1,6 +1,6 @@
 --- add-type-extension.json
 +++ patched
-@@ -11,7 +11,10 @@
+@@ -38,7 +38,10 @@
          "required": [
            "message"
          ],
@@ -10,7 +10,7 @@
 +          "mumble": "frotz"
 +        }
        },
-       "Tree": {
+       "SubType": {
          "properties": {
 
 

--- a/tests/cases/simple/output/add-type-extension.out
+++ b/tests/cases/simple/output/add-type-extension.out
@@ -1,6 +1,6 @@
 --- add-type-extension.json
 +++ patched
-@@ -38,7 +38,10 @@
+@@ -43,7 +43,10 @@
          "required": [
            "message"
          ],

--- a/tests/cases/simple/output/allof-to-anyof.out
+++ b/tests/cases/simple/output/allof-to-anyof.out
@@ -1,0 +1,36 @@
+--- allof-to-anyof.json
++++ patched
+@@ -8,12 +8,12 @@
+             "type": "string"
+           },
+           "via_allof": {
+-            "allOf": [
++            "anyOf": [
+               {
+                 "$ref": "#/components/schemas/SubType"
+               }
+             ],
+-            "description": "Via allOf."
++            "description": "Via anyOf."
+           },
+           "via_anyof": {
+             "anyOf": [
+
+
+Result for patch:
+[
+    Change {
+        message: "schema metadata changed",
+        old_path: [
+            "#/components/schemas/GreetingResponse/properties/via_allof",
+            "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",
+        ],
+        new_path: [
+            "#/components/schemas/GreetingResponse/properties/via_allof",
+            "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",
+        ],
+        comparison: Output,
+        class: Trivial,
+        details: Metadata,
+    },
+]

--- a/tests/cases/simple/output/allof-to-anyof.out
+++ b/tests/cases/simple/output/allof-to-anyof.out
@@ -1,7 +1,7 @@
 --- allof-to-anyof.json
 +++ patched
-@@ -8,12 +8,12 @@
-             "type": "string"
+@@ -13,12 +13,12 @@
+             }
            },
            "via_allof": {
 -            "allOf": [

--- a/tests/cases/simple/output/allof-to-oneof-with-type-change.out
+++ b/tests/cases/simple/output/allof-to-oneof-with-type-change.out
@@ -1,7 +1,7 @@
 --- allof-to-oneof-with-type-change.json
 +++ patched
-@@ -8,12 +8,12 @@
-             "type": "string"
+@@ -13,12 +13,12 @@
+             }
            },
            "via_allof": {
 -            "allOf": [
@@ -16,7 +16,7 @@
            },
            "via_anyof": {
              "anyOf": [
-@@ -43,7 +43,7 @@
+@@ -48,7 +48,7 @@
        "SubType": {
          "properties": {
            "value": {

--- a/tests/cases/simple/output/allof-to-oneof-with-type-change.out
+++ b/tests/cases/simple/output/allof-to-oneof-with-type-change.out
@@ -1,0 +1,62 @@
+--- allof-to-oneof-with-type-change.json
++++ patched
+@@ -8,12 +8,12 @@
+             "type": "string"
+           },
+           "via_allof": {
+-            "allOf": [
++            "description": "Via oneOf.",
++            "oneOf": [
+               {
+                 "$ref": "#/components/schemas/SubType"
+               }
+-            ],
+-            "description": "Via allOf."
++            ]
+           },
+           "via_anyof": {
+             "anyOf": [
+@@ -43,7 +43,7 @@
+       "SubType": {
+         "properties": {
+           "value": {
+-            "type": "string"
++            "type": "integer"
+           }
+         },
+         "type": "object"
+
+
+Result for patch:
+[
+    Change {
+        message: "schema metadata changed",
+        old_path: [
+            "#/components/schemas/GreetingResponse/properties/via_allof",
+            "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",
+        ],
+        new_path: [
+            "#/components/schemas/GreetingResponse/properties/via_allof",
+            "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",
+        ],
+        comparison: Output,
+        class: Trivial,
+        details: Metadata,
+    },
+    Change {
+        message: "schema types changed",
+        old_path: [
+            "#/components/schemas/SubType/properties/value",
+            "#/components/schemas/GreetingResponse/properties/via_allof/0/$ref",
+            "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",
+        ],
+        new_path: [
+            "#/components/schemas/SubType/properties/value",
+            "#/components/schemas/GreetingResponse/properties/via_allof/0/$ref",
+            "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",
+        ],
+        comparison: Output,
+        class: Incompatible,
+        details: UnknownDifference,
+    },
+]

--- a/tests/cases/simple/output/allof-to-oneof.out
+++ b/tests/cases/simple/output/allof-to-oneof.out
@@ -1,0 +1,37 @@
+--- allof-to-oneof.json
++++ patched
+@@ -8,12 +8,12 @@
+             "type": "string"
+           },
+           "via_allof": {
+-            "allOf": [
++            "description": "Via oneOf.",
++            "oneOf": [
+               {
+                 "$ref": "#/components/schemas/SubType"
+               }
+-            ],
+-            "description": "Via allOf."
++            ]
+           },
+           "via_anyof": {
+             "anyOf": [
+
+
+Result for patch:
+[
+    Change {
+        message: "schema metadata changed",
+        old_path: [
+            "#/components/schemas/GreetingResponse/properties/via_allof",
+            "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",
+        ],
+        new_path: [
+            "#/components/schemas/GreetingResponse/properties/via_allof",
+            "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",
+        ],
+        comparison: Output,
+        class: Trivial,
+        details: Metadata,
+    },
+]

--- a/tests/cases/simple/output/allof-to-oneof.out
+++ b/tests/cases/simple/output/allof-to-oneof.out
@@ -1,7 +1,7 @@
 --- allof-to-oneof.json
 +++ patched
-@@ -8,12 +8,12 @@
-             "type": "string"
+@@ -13,12 +13,12 @@
+             }
            },
            "via_allof": {
 -            "allOf": [

--- a/tests/cases/simple/output/allof-to-ref-with-type-change.out
+++ b/tests/cases/simple/output/allof-to-ref-with-type-change.out
@@ -1,7 +1,7 @@
 --- allof-to-ref-with-type-change.json
 +++ patched
-@@ -8,12 +8,7 @@
-             "type": "string"
+@@ -13,12 +13,7 @@
+             }
            },
            "via_allof": {
 -            "allOf": [
@@ -14,7 +14,7 @@
            },
            "via_anyof": {
              "anyOf": [
-@@ -42,6 +37,9 @@
+@@ -47,6 +42,9 @@
        },
        "SubType": {
          "properties": {

--- a/tests/cases/simple/output/allof-to-ref-with-type-change.out
+++ b/tests/cases/simple/output/allof-to-ref-with-type-change.out
@@ -29,7 +29,7 @@
 Result for patch:
 [
     Change {
-        message: "schema metadata changed",
+        message: "schema metadata removed",
         old_path: [
             "#/components/schemas/GreetingResponse/properties/via_allof",
             "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",

--- a/tests/cases/simple/output/allof-to-ref-with-type-change.out
+++ b/tests/cases/simple/output/allof-to-ref-with-type-change.out
@@ -1,0 +1,61 @@
+--- allof-to-ref-with-type-change.json
++++ patched
+@@ -8,12 +8,7 @@
+             "type": "string"
+           },
+           "via_allof": {
+-            "allOf": [
+-              {
+-                "$ref": "#/components/schemas/SubType"
+-              }
+-            ],
+-            "description": "Via allOf."
++            "$ref": "#/components/schemas/SubType"
+           },
+           "via_anyof": {
+             "anyOf": [
+@@ -42,6 +37,9 @@
+       },
+       "SubType": {
+         "properties": {
++          "extra": {
++            "type": "integer"
++          },
+           "value": {
+             "type": "string"
+           }
+
+
+Result for patch:
+[
+    Change {
+        message: "schema metadata changed",
+        old_path: [
+            "#/components/schemas/GreetingResponse/properties/via_allof",
+            "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",
+        ],
+        new_path: [
+            "#/components/schemas/GreetingResponse/properties/via_allof",
+            "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",
+        ],
+        comparison: Output,
+        class: Trivial,
+        details: Metadata,
+    },
+    Change {
+        message: "object properties changed",
+        old_path: [
+            "#/components/schemas/SubType",
+            "#/components/schemas/GreetingResponse/properties/via_allof/0/$ref",
+            "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",
+        ],
+        new_path: [
+            "#/components/schemas/SubType",
+            "#/components/schemas/GreetingResponse/properties/via_allof/$ref",
+            "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",
+        ],
+        comparison: Output,
+        class: Unhandled,
+        details: UnknownDifference,
+    },
+]

--- a/tests/cases/simple/output/allof-to-ref.out
+++ b/tests/cases/simple/output/allof-to-ref.out
@@ -1,0 +1,35 @@
+--- allof-to-ref.json
++++ patched
+@@ -8,12 +8,7 @@
+             "type": "string"
+           },
+           "via_allof": {
+-            "allOf": [
+-              {
+-                "$ref": "#/components/schemas/SubType"
+-              }
+-            ],
+-            "description": "Via allOf."
++            "$ref": "#/components/schemas/SubType"
+           },
+           "via_anyof": {
+             "anyOf": [
+
+
+Result for patch:
+[
+    Change {
+        message: "schema metadata changed",
+        old_path: [
+            "#/components/schemas/GreetingResponse/properties/via_allof",
+            "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",
+        ],
+        new_path: [
+            "#/components/schemas/GreetingResponse/properties/via_allof",
+            "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",
+        ],
+        comparison: Output,
+        class: Trivial,
+        details: Metadata,
+    },
+]

--- a/tests/cases/simple/output/allof-to-ref.out
+++ b/tests/cases/simple/output/allof-to-ref.out
@@ -19,7 +19,7 @@
 Result for patch:
 [
     Change {
-        message: "schema metadata changed",
+        message: "schema metadata removed",
         old_path: [
             "#/components/schemas/GreetingResponse/properties/via_allof",
             "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",

--- a/tests/cases/simple/output/anyof-to-allof.out
+++ b/tests/cases/simple/output/anyof-to-allof.out
@@ -1,6 +1,6 @@
 --- anyof-to-allof.json
 +++ patched
-@@ -16,12 +16,12 @@
+@@ -21,12 +21,12 @@
              "description": "Via allOf."
            },
            "via_anyof": {

--- a/tests/cases/simple/output/anyof-to-allof.out
+++ b/tests/cases/simple/output/anyof-to-allof.out
@@ -1,0 +1,36 @@
+--- anyof-to-allof.json
++++ patched
+@@ -16,12 +16,12 @@
+             "description": "Via allOf."
+           },
+           "via_anyof": {
+-            "anyOf": [
++            "allOf": [
+               {
+                 "$ref": "#/components/schemas/SubType"
+               }
+             ],
+-            "description": "Via anyOf."
++            "description": "Via allOf."
+           },
+           "via_oneof": {
+             "description": "Via oneOf.",
+
+
+Result for patch:
+[
+    Change {
+        message: "schema metadata changed",
+        old_path: [
+            "#/components/schemas/GreetingResponse/properties/via_anyof",
+            "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",
+        ],
+        new_path: [
+            "#/components/schemas/GreetingResponse/properties/via_anyof",
+            "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",
+        ],
+        comparison: Output,
+        class: Trivial,
+        details: Metadata,
+    },
+]

--- a/tests/cases/simple/output/anyof-to-oneof.out
+++ b/tests/cases/simple/output/anyof-to-oneof.out
@@ -1,0 +1,37 @@
+--- anyof-to-oneof.json
++++ patched
+@@ -16,12 +16,12 @@
+             "description": "Via allOf."
+           },
+           "via_anyof": {
+-            "anyOf": [
++            "description": "Via oneOf.",
++            "oneOf": [
+               {
+                 "$ref": "#/components/schemas/SubType"
+               }
+-            ],
+-            "description": "Via anyOf."
++            ]
+           },
+           "via_oneof": {
+             "description": "Via oneOf.",
+
+
+Result for patch:
+[
+    Change {
+        message: "schema metadata changed",
+        old_path: [
+            "#/components/schemas/GreetingResponse/properties/via_anyof",
+            "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",
+        ],
+        new_path: [
+            "#/components/schemas/GreetingResponse/properties/via_anyof",
+            "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",
+        ],
+        comparison: Output,
+        class: Trivial,
+        details: Metadata,
+    },
+]

--- a/tests/cases/simple/output/anyof-to-oneof.out
+++ b/tests/cases/simple/output/anyof-to-oneof.out
@@ -1,6 +1,6 @@
 --- anyof-to-oneof.json
 +++ patched
-@@ -16,12 +16,12 @@
+@@ -21,12 +21,12 @@
              "description": "Via allOf."
            },
            "via_anyof": {

--- a/tests/cases/simple/output/anyof-to-ref.out
+++ b/tests/cases/simple/output/anyof-to-ref.out
@@ -1,6 +1,6 @@
 --- anyof-to-ref.json
 +++ patched
-@@ -16,12 +16,7 @@
+@@ -21,12 +21,7 @@
              "description": "Via allOf."
            },
            "via_anyof": {

--- a/tests/cases/simple/output/anyof-to-ref.out
+++ b/tests/cases/simple/output/anyof-to-ref.out
@@ -1,0 +1,35 @@
+--- anyof-to-ref.json
++++ patched
+@@ -16,12 +16,7 @@
+             "description": "Via allOf."
+           },
+           "via_anyof": {
+-            "anyOf": [
+-              {
+-                "$ref": "#/components/schemas/SubType"
+-              }
+-            ],
+-            "description": "Via anyOf."
++            "$ref": "#/components/schemas/SubType"
+           },
+           "via_oneof": {
+             "description": "Via oneOf.",
+
+
+Result for patch:
+[
+    Change {
+        message: "schema metadata changed",
+        old_path: [
+            "#/components/schemas/GreetingResponse/properties/via_anyof",
+            "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",
+        ],
+        new_path: [
+            "#/components/schemas/GreetingResponse/properties/via_anyof",
+            "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",
+        ],
+        comparison: Output,
+        class: Trivial,
+        details: Metadata,
+    },
+]

--- a/tests/cases/simple/output/anyof-to-ref.out
+++ b/tests/cases/simple/output/anyof-to-ref.out
@@ -19,7 +19,7 @@
 Result for patch:
 [
     Change {
-        message: "schema metadata changed",
+        message: "schema metadata removed",
         old_path: [
             "#/components/schemas/GreetingResponse/properties/via_anyof",
             "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",

--- a/tests/cases/simple/output/change-operation-parameter-requirement.out
+++ b/tests/cases/simple/output/change-operation-parameter-requirement.out
@@ -1,6 +1,6 @@
 --- change-operation-parameter-requirement.json
 +++ patched
-@@ -83,7 +83,7 @@
+@@ -88,7 +88,7 @@
              "description": "Language for the greeting",
              "in": "query",
              "name": "language",

--- a/tests/cases/simple/output/change-operation-parameter-requirement.out
+++ b/tests/cases/simple/output/change-operation-parameter-requirement.out
@@ -1,6 +1,6 @@
 --- change-operation-parameter-requirement.json
 +++ patched
-@@ -48,7 +48,7 @@
+@@ -83,7 +83,7 @@
              "description": "Language for the greeting",
              "in": "query",
              "name": "language",

--- a/tests/cases/simple/output/change-operation-parameter-type.out
+++ b/tests/cases/simple/output/change-operation-parameter-type.out
@@ -1,6 +1,6 @@
 --- change-operation-parameter-type.json
 +++ patched
-@@ -85,7 +85,7 @@
+@@ -90,7 +90,7 @@
              "name": "language",
              "required": false,
              "schema": {

--- a/tests/cases/simple/output/change-operation-parameter-type.out
+++ b/tests/cases/simple/output/change-operation-parameter-type.out
@@ -1,6 +1,6 @@
 --- change-operation-parameter-type.json
 +++ patched
-@@ -50,7 +50,7 @@
+@@ -85,7 +85,7 @@
              "name": "language",
              "required": false,
              "schema": {

--- a/tests/cases/simple/output/change-property-type.out
+++ b/tests/cases/simple/output/change-property-type.out
@@ -7,8 +7,8 @@
 -            "type": "string"
 +            "type": "integer"
            },
-           "via_allof": {
-             "allOf": [
+           "not_a_number": {
+             "not": {
 
 
 Result for patch:

--- a/tests/cases/simple/output/inline-to-allof.out
+++ b/tests/cases/simple/output/inline-to-allof.out
@@ -1,0 +1,33 @@
+--- inline-to-allof.json
++++ patched
+@@ -81,7 +81,12 @@
+             "in": "path",
+             "name": "name",
+             "schema": {
+-              "type": "string"
++              "allOf": [
++                {
++                  "type": "string"
++                }
++              ],
++              "description": "A string parameter"
+             }
+           },
+           {
+
+
+Result for patch:
+[
+    Change {
+        message: "schema metadata changed",
+        old_path: [
+            "#/paths/~1hello~1{name}/get/parameters/0/schema",
+        ],
+        new_path: [
+            "#/paths/~1hello~1{name}/get/parameters/0/schema",
+        ],
+        comparison: Input,
+        class: Trivial,
+        details: Metadata,
+    },
+]

--- a/tests/cases/simple/output/inline-to-allof.out
+++ b/tests/cases/simple/output/inline-to-allof.out
@@ -19,7 +19,7 @@
 Result for patch:
 [
     Change {
-        message: "schema metadata changed",
+        message: "schema metadata added",
         old_path: [
             "#/paths/~1hello~1{name}/get/parameters/0/schema",
         ],

--- a/tests/cases/simple/output/modify-cycle-type.out
+++ b/tests/cases/simple/output/modify-cycle-type.out
@@ -1,6 +1,6 @@
 --- modify-cycle-type.json
 +++ patched
-@@ -51,10 +51,7 @@
+@@ -56,10 +56,7 @@
        "Tree": {
          "properties": {
            "children": {

--- a/tests/cases/simple/output/modify-cycle-type.out
+++ b/tests/cases/simple/output/modify-cycle-type.out
@@ -1,6 +1,6 @@
 --- modify-cycle-type.json
 +++ patched
-@@ -16,10 +16,7 @@
+@@ -51,10 +51,7 @@
        "Tree": {
          "properties": {
            "children": {

--- a/tests/cases/simple/output/not-inner-to-allof.out
+++ b/tests/cases/simple/output/not-inner-to-allof.out
@@ -19,7 +19,7 @@
 Result for patch:
 [
     Change {
-        message: "schema metadata changed",
+        message: "schema metadata added",
         old_path: [
             "#/components/schemas/GreetingResponse/properties/not_a_number/not",
             "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",

--- a/tests/cases/simple/output/not-inner-to-allof.out
+++ b/tests/cases/simple/output/not-inner-to-allof.out
@@ -1,19 +1,19 @@
---- allof-to-ref.json
+--- not-inner-to-allof.json
 +++ patched
-@@ -13,12 +13,7 @@
+@@ -9,7 +9,12 @@
+           },
+           "not_a_number": {
+             "not": {
+-              "type": "number"
++              "allOf": [
++                {
++                  "type": "number"
++                }
++              ],
++              "description": "A number type"
              }
            },
            "via_allof": {
--            "allOf": [
--              {
--                "$ref": "#/components/schemas/SubType"
--              }
--            ],
--            "description": "Via allOf."
-+            "$ref": "#/components/schemas/SubType"
-           },
-           "via_anyof": {
-             "anyOf": [
 
 
 Result for patch:
@@ -21,11 +21,11 @@ Result for patch:
     Change {
         message: "schema metadata changed",
         old_path: [
-            "#/components/schemas/GreetingResponse/properties/via_allof",
+            "#/components/schemas/GreetingResponse/properties/not_a_number/not",
             "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",
         ],
         new_path: [
-            "#/components/schemas/GreetingResponse/properties/via_allof",
+            "#/components/schemas/GreetingResponse/properties/not_a_number/not",
             "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",
         ],
         comparison: Output,

--- a/tests/cases/simple/output/not-to-allof.out
+++ b/tests/cases/simple/output/not-to-allof.out
@@ -1,0 +1,39 @@
+--- not-to-allof.json
++++ patched
+@@ -8,9 +8,14 @@
+             "type": "string"
+           },
+           "not_a_number": {
+-            "not": {
+-              "type": "number"
+-            }
++            "allOf": [
++              {
++                "not": {
++                  "type": "number"
++                }
++              }
++            ],
++            "description": "Not a number, wrapped in allOf"
+           },
+           "via_allof": {
+             "allOf": [
+
+
+Result for patch:
+[
+    Change {
+        message: "schema metadata changed",
+        old_path: [
+            "#/components/schemas/GreetingResponse/properties/not_a_number",
+            "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",
+        ],
+        new_path: [
+            "#/components/schemas/GreetingResponse/properties/not_a_number",
+            "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",
+        ],
+        comparison: Output,
+        class: Trivial,
+        details: Metadata,
+    },
+]

--- a/tests/cases/simple/output/not-to-allof.out
+++ b/tests/cases/simple/output/not-to-allof.out
@@ -23,7 +23,7 @@
 Result for patch:
 [
     Change {
-        message: "schema metadata changed",
+        message: "schema metadata added",
         old_path: [
             "#/components/schemas/GreetingResponse/properties/not_a_number",
             "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",

--- a/tests/cases/simple/output/oneof-to-allof.out
+++ b/tests/cases/simple/output/oneof-to-allof.out
@@ -1,0 +1,37 @@
+--- oneof-to-allof.json
++++ patched
+@@ -24,12 +24,12 @@
+             "description": "Via anyOf."
+           },
+           "via_oneof": {
+-            "description": "Via oneOf.",
+-            "oneOf": [
++            "allOf": [
+               {
+                 "$ref": "#/components/schemas/SubType"
+               }
+-            ]
++            ],
++            "description": "Via allOf."
+           },
+           "via_ref": {
+             "$ref": "#/components/schemas/SubType"
+
+
+Result for patch:
+[
+    Change {
+        message: "schema metadata changed",
+        old_path: [
+            "#/components/schemas/GreetingResponse/properties/via_oneof",
+            "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",
+        ],
+        new_path: [
+            "#/components/schemas/GreetingResponse/properties/via_oneof",
+            "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",
+        ],
+        comparison: Output,
+        class: Trivial,
+        details: Metadata,
+    },
+]

--- a/tests/cases/simple/output/oneof-to-allof.out
+++ b/tests/cases/simple/output/oneof-to-allof.out
@@ -1,6 +1,6 @@
 --- oneof-to-allof.json
 +++ patched
-@@ -24,12 +24,12 @@
+@@ -29,12 +29,12 @@
              "description": "Via anyOf."
            },
            "via_oneof": {

--- a/tests/cases/simple/output/oneof-to-anyof.out
+++ b/tests/cases/simple/output/oneof-to-anyof.out
@@ -1,0 +1,37 @@
+--- oneof-to-anyof.json
++++ patched
+@@ -24,12 +24,12 @@
+             "description": "Via anyOf."
+           },
+           "via_oneof": {
+-            "description": "Via oneOf.",
+-            "oneOf": [
++            "anyOf": [
+               {
+                 "$ref": "#/components/schemas/SubType"
+               }
+-            ]
++            ],
++            "description": "Via anyOf."
+           },
+           "via_ref": {
+             "$ref": "#/components/schemas/SubType"
+
+
+Result for patch:
+[
+    Change {
+        message: "schema metadata changed",
+        old_path: [
+            "#/components/schemas/GreetingResponse/properties/via_oneof",
+            "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",
+        ],
+        new_path: [
+            "#/components/schemas/GreetingResponse/properties/via_oneof",
+            "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",
+        ],
+        comparison: Output,
+        class: Trivial,
+        details: Metadata,
+    },
+]

--- a/tests/cases/simple/output/oneof-to-anyof.out
+++ b/tests/cases/simple/output/oneof-to-anyof.out
@@ -1,6 +1,6 @@
 --- oneof-to-anyof.json
 +++ patched
-@@ -24,12 +24,12 @@
+@@ -29,12 +29,12 @@
              "description": "Via anyOf."
            },
            "via_oneof": {

--- a/tests/cases/simple/output/oneof-to-ref.out
+++ b/tests/cases/simple/output/oneof-to-ref.out
@@ -1,0 +1,35 @@
+--- oneof-to-ref.json
++++ patched
+@@ -24,12 +24,7 @@
+             "description": "Via anyOf."
+           },
+           "via_oneof": {
+-            "description": "Via oneOf.",
+-            "oneOf": [
+-              {
+-                "$ref": "#/components/schemas/SubType"
+-              }
+-            ]
++            "$ref": "#/components/schemas/SubType"
+           },
+           "via_ref": {
+             "$ref": "#/components/schemas/SubType"
+
+
+Result for patch:
+[
+    Change {
+        message: "schema metadata changed",
+        old_path: [
+            "#/components/schemas/GreetingResponse/properties/via_oneof",
+            "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",
+        ],
+        new_path: [
+            "#/components/schemas/GreetingResponse/properties/via_oneof",
+            "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",
+        ],
+        comparison: Output,
+        class: Trivial,
+        details: Metadata,
+    },
+]

--- a/tests/cases/simple/output/oneof-to-ref.out
+++ b/tests/cases/simple/output/oneof-to-ref.out
@@ -1,6 +1,6 @@
 --- oneof-to-ref.json
 +++ patched
-@@ -24,12 +24,7 @@
+@@ -29,12 +29,7 @@
              "description": "Via anyOf."
            },
            "via_oneof": {

--- a/tests/cases/simple/output/oneof-to-ref.out
+++ b/tests/cases/simple/output/oneof-to-ref.out
@@ -19,7 +19,7 @@
 Result for patch:
 [
     Change {
-        message: "schema metadata changed",
+        message: "schema metadata removed",
         old_path: [
             "#/components/schemas/GreetingResponse/properties/via_oneof",
             "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",

--- a/tests/cases/simple/output/ref-to-allof.out
+++ b/tests/cases/simple/output/ref-to-allof.out
@@ -1,6 +1,6 @@
 --- ref-to-allof.json
 +++ patched
-@@ -32,7 +32,12 @@
+@@ -37,7 +37,12 @@
              ]
            },
            "via_ref": {

--- a/tests/cases/simple/output/ref-to-allof.out
+++ b/tests/cases/simple/output/ref-to-allof.out
@@ -1,0 +1,35 @@
+--- ref-to-allof.json
++++ patched
+@@ -32,7 +32,12 @@
+             ]
+           },
+           "via_ref": {
+-            "$ref": "#/components/schemas/SubType"
++            "allOf": [
++              {
++                "$ref": "#/components/schemas/SubType"
++              }
++            ],
++            "description": "Via allOf."
+           }
+         },
+         "required": [
+
+
+Result for patch:
+[
+    Change {
+        message: "schema metadata changed",
+        old_path: [
+            "#/components/schemas/GreetingResponse/properties/via_ref",
+            "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",
+        ],
+        new_path: [
+            "#/components/schemas/GreetingResponse/properties/via_ref",
+            "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",
+        ],
+        comparison: Output,
+        class: Trivial,
+        details: Metadata,
+    },
+]

--- a/tests/cases/simple/output/ref-to-allof.out
+++ b/tests/cases/simple/output/ref-to-allof.out
@@ -19,7 +19,7 @@
 Result for patch:
 [
     Change {
-        message: "schema metadata changed",
+        message: "schema metadata added",
         old_path: [
             "#/components/schemas/GreetingResponse/properties/via_ref",
             "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",

--- a/tests/cases/simple/output/ref-to-anyof.out
+++ b/tests/cases/simple/output/ref-to-anyof.out
@@ -1,6 +1,6 @@
 --- ref-to-anyof.json
 +++ patched
-@@ -32,7 +32,12 @@
+@@ -37,7 +37,12 @@
              ]
            },
            "via_ref": {

--- a/tests/cases/simple/output/ref-to-anyof.out
+++ b/tests/cases/simple/output/ref-to-anyof.out
@@ -1,0 +1,35 @@
+--- ref-to-anyof.json
++++ patched
+@@ -32,7 +32,12 @@
+             ]
+           },
+           "via_ref": {
+-            "$ref": "#/components/schemas/SubType"
++            "anyOf": [
++              {
++                "$ref": "#/components/schemas/SubType"
++              }
++            ],
++            "description": "Via anyOf."
+           }
+         },
+         "required": [
+
+
+Result for patch:
+[
+    Change {
+        message: "schema metadata changed",
+        old_path: [
+            "#/components/schemas/GreetingResponse/properties/via_ref",
+            "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",
+        ],
+        new_path: [
+            "#/components/schemas/GreetingResponse/properties/via_ref",
+            "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",
+        ],
+        comparison: Output,
+        class: Trivial,
+        details: Metadata,
+    },
+]

--- a/tests/cases/simple/output/ref-to-anyof.out
+++ b/tests/cases/simple/output/ref-to-anyof.out
@@ -19,7 +19,7 @@
 Result for patch:
 [
     Change {
-        message: "schema metadata changed",
+        message: "schema metadata added",
         old_path: [
             "#/components/schemas/GreetingResponse/properties/via_ref",
             "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",

--- a/tests/cases/simple/output/ref-to-inline-allof.out
+++ b/tests/cases/simple/output/ref-to-inline-allof.out
@@ -1,0 +1,56 @@
+--- ref-to-inline-allof.json
++++ patched
+@@ -37,7 +37,18 @@
+             ]
+           },
+           "via_ref": {
+-            "$ref": "#/components/schemas/SubType"
++            "allOf": [
++              {
++                "description": "Greeting response type",
++                "properties": {
++                  "value": {
++                    "type": "string"
++                  }
++                },
++                "type": "object"
++              }
++            ],
++            "description": "A greeting response"
+           }
+         },
+         "required": [
+
+
+Result for patch:
+[
+    Change {
+        message: "schema metadata changed",
+        old_path: [
+            "#/components/schemas/GreetingResponse/properties/via_ref",
+            "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",
+        ],
+        new_path: [
+            "#/components/schemas/GreetingResponse/properties/via_ref",
+            "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",
+        ],
+        comparison: Output,
+        class: Trivial,
+        details: Metadata,
+    },
+    Change {
+        message: "schema metadata changed",
+        old_path: [
+            "#/components/schemas/SubType",
+            "#/components/schemas/GreetingResponse/properties/via_ref/$ref",
+            "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",
+        ],
+        new_path: [
+            "#/components/schemas/GreetingResponse/properties/via_ref/0",
+            "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",
+        ],
+        comparison: Output,
+        class: Trivial,
+        details: Metadata,
+    },
+]

--- a/tests/cases/simple/output/ref-to-inline-allof.out
+++ b/tests/cases/simple/output/ref-to-inline-allof.out
@@ -25,7 +25,7 @@
 Result for patch:
 [
     Change {
-        message: "schema metadata changed",
+        message: "schema metadata added",
         old_path: [
             "#/components/schemas/GreetingResponse/properties/via_ref",
             "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",

--- a/tests/cases/simple/output/ref-to-oneof.out
+++ b/tests/cases/simple/output/ref-to-oneof.out
@@ -1,6 +1,6 @@
 --- ref-to-oneof.json
 +++ patched
-@@ -32,7 +32,12 @@
+@@ -37,7 +37,12 @@
              ]
            },
            "via_ref": {

--- a/tests/cases/simple/output/ref-to-oneof.out
+++ b/tests/cases/simple/output/ref-to-oneof.out
@@ -1,0 +1,35 @@
+--- ref-to-oneof.json
++++ patched
+@@ -32,7 +32,12 @@
+             ]
+           },
+           "via_ref": {
+-            "$ref": "#/components/schemas/SubType"
++            "description": "Via oneOf.",
++            "oneOf": [
++              {
++                "$ref": "#/components/schemas/SubType"
++              }
++            ]
+           }
+         },
+         "required": [
+
+
+Result for patch:
+[
+    Change {
+        message: "schema metadata changed",
+        old_path: [
+            "#/components/schemas/GreetingResponse/properties/via_ref",
+            "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",
+        ],
+        new_path: [
+            "#/components/schemas/GreetingResponse/properties/via_ref",
+            "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",
+        ],
+        comparison: Output,
+        class: Trivial,
+        details: Metadata,
+    },
+]

--- a/tests/cases/simple/output/ref-to-oneof.out
+++ b/tests/cases/simple/output/ref-to-oneof.out
@@ -19,7 +19,7 @@
 Result for patch:
 [
     Change {
-        message: "schema metadata changed",
+        message: "schema metadata added",
         old_path: [
             "#/components/schemas/GreetingResponse/properties/via_ref",
             "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",

--- a/tests/cases/simple/output/remove-operation-parameter.out
+++ b/tests/cases/simple/output/remove-operation-parameter.out
@@ -1,6 +1,6 @@
 --- remove-operation-parameter.json
 +++ patched
-@@ -43,15 +43,6 @@
+@@ -78,15 +78,6 @@
              "schema": {
                "type": "string"
              }

--- a/tests/cases/simple/output/remove-operation-parameter.out
+++ b/tests/cases/simple/output/remove-operation-parameter.out
@@ -1,6 +1,6 @@
 --- remove-operation-parameter.json
 +++ patched
-@@ -78,15 +78,6 @@
+@@ -83,15 +83,6 @@
              "schema": {
                "type": "string"
              }

--- a/tests/cases/simple/output/remove-operation.out
+++ b/tests/cases/simple/output/remove-operation.out
@@ -1,6 +1,6 @@
 --- remove-operation.json
 +++ patched
-@@ -69,18 +69,7 @@
+@@ -104,18 +104,7 @@
          "summary": "Say hello"
        }
      },

--- a/tests/cases/simple/output/remove-operation.out
+++ b/tests/cases/simple/output/remove-operation.out
@@ -1,6 +1,6 @@
 --- remove-operation.json
 +++ patched
-@@ -104,18 +104,7 @@
+@@ -109,18 +109,7 @@
          "summary": "Say hello"
        }
      },

--- a/tests/cases/simple/output/type-indirection.out
+++ b/tests/cases/simple/output/type-indirection.out
@@ -7,10 +7,10 @@
 -            "description": "The greeting message",
 -            "type": "string"
 +            "$ref": "#/components/schemas/GreetingResponseMessage"
-           }
-         },
-         "required": [
-@@ -13,6 +12,13 @@
+           },
+           "via_allof": {
+             "allOf": [
+@@ -40,6 +39,13 @@
          ],
          "type": "object"
        },
@@ -21,9 +21,9 @@
 +          "jank": true
 +        }
 +      },
-       "Tree": {
+       "SubType": {
          "properties": {
-           "children": {
+           "value": {
 
 
 Result for patch:

--- a/tests/cases/simple/output/type-indirection.out
+++ b/tests/cases/simple/output/type-indirection.out
@@ -8,9 +8,9 @@
 -            "type": "string"
 +            "$ref": "#/components/schemas/GreetingResponseMessage"
            },
-           "via_allof": {
-             "allOf": [
-@@ -40,6 +39,13 @@
+           "not_a_number": {
+             "not": {
+@@ -45,6 +44,13 @@
          ],
          "type": "object"
        },

--- a/tests/cases/simple/output/type-rename.out
+++ b/tests/cases/simple/output/type-rename.out
@@ -9,7 +9,7 @@
          "properties": {
            "message": {
              "description": "The greeting message",
-@@ -94,7 +94,7 @@
+@@ -99,7 +99,7 @@
              "content": {
                "application/json": {
                  "schema": {

--- a/tests/cases/simple/output/type-rename.out
+++ b/tests/cases/simple/output/type-rename.out
@@ -9,7 +9,7 @@
          "properties": {
            "message": {
              "description": "The greeting message",
-@@ -59,7 +59,7 @@
+@@ -94,7 +94,7 @@
              "content": {
                "application/json": {
                  "schema": {

--- a/tests/cases/simple/output/unhandled-add-prop.out
+++ b/tests/cases/simple/output/unhandled-add-prop.out
@@ -1,13 +1,17 @@
 --- unhandled-add-prop.json
 +++ patched
-@@ -6,10 +6,15 @@
-           "message": {
+@@ -7,6 +7,10 @@
              "description": "The greeting message",
              "type": "string"
-+          },
+           },
 +          "source": {
 +            "description": "Where the greeting originated",
 +            "type": "string"
++          },
+           "via_allof": {
+             "allOf": [
+               {
+@@ -36,7 +40,8 @@
            }
          },
          "required": [

--- a/tests/cases/simple/output/unhandled-add-prop.out
+++ b/tests/cases/simple/output/unhandled-add-prop.out
@@ -1,8 +1,8 @@
 --- unhandled-add-prop.json
 +++ patched
-@@ -7,6 +7,10 @@
-             "description": "The greeting message",
-             "type": "string"
+@@ -12,6 +12,10 @@
+               "type": "number"
+             }
            },
 +          "source": {
 +            "description": "Where the greeting originated",
@@ -11,7 +11,7 @@
            "via_allof": {
              "allOf": [
                {
-@@ -36,7 +40,8 @@
+@@ -41,7 +45,8 @@
            }
          },
          "required": [

--- a/tests/cases/simple/output/wrapper-unchanged-with-type-change.out
+++ b/tests/cases/simple/output/wrapper-unchanged-with-type-change.out
@@ -1,6 +1,6 @@
 --- wrapper-unchanged-with-type-change.json
 +++ patched
-@@ -43,7 +43,7 @@
+@@ -48,7 +48,7 @@
        "SubType": {
          "properties": {
            "value": {

--- a/tests/cases/simple/output/wrapper-unchanged-with-type-change.out
+++ b/tests/cases/simple/output/wrapper-unchanged-with-type-change.out
@@ -1,14 +1,14 @@
---- change-property-type.json
+--- wrapper-unchanged-with-type-change.json
 +++ patched
-@@ -5,7 +5,7 @@
+@@ -43,7 +43,7 @@
+       "SubType": {
          "properties": {
-           "message": {
-             "description": "The greeting message",
+           "value": {
 -            "type": "string"
 +            "type": "integer"
-           },
-           "via_allof": {
-             "allOf": [
+           }
+         },
+         "type": "object"
 
 
 Result for patch:
@@ -16,11 +16,13 @@ Result for patch:
     Change {
         message: "schema types changed",
         old_path: [
-            "#/components/schemas/GreetingResponse/properties/message",
+            "#/components/schemas/SubType/properties/value",
+            "#/components/schemas/GreetingResponse/properties/via_allof/0/$ref",
             "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",
         ],
         new_path: [
-            "#/components/schemas/GreetingResponse/properties/message",
+            "#/components/schemas/SubType/properties/value",
+            "#/components/schemas/GreetingResponse/properties/via_allof/0/$ref",
             "#/paths/~1hello~1{name}/get/responses/200/content/application~1json/schema/$ref",
         ],
         comparison: Output,

--- a/tests/cases/simple/patch/allof-to-anyof.json
+++ b/tests/cases/simple/patch/allof-to-anyof.json
@@ -1,0 +1,14 @@
+[
+  {
+    "op": "replace",
+    "path": "/components/schemas/GreetingResponse/properties/via_allof",
+    "value": {
+      "description": "Via anyOf.",
+      "anyOf": [
+        {
+          "$ref": "#/components/schemas/SubType"
+        }
+      ]
+    }
+  }
+]

--- a/tests/cases/simple/patch/allof-to-oneof-with-type-change.json
+++ b/tests/cases/simple/patch/allof-to-oneof-with-type-change.json
@@ -1,0 +1,19 @@
+[
+  {
+    "op": "replace",
+    "path": "/components/schemas/GreetingResponse/properties/via_allof",
+    "value": {
+      "description": "Via oneOf.",
+      "oneOf": [
+        {
+          "$ref": "#/components/schemas/SubType"
+        }
+      ]
+    }
+  },
+  {
+    "op": "replace",
+    "path": "/components/schemas/SubType/properties/value/type",
+    "value": "integer"
+  }
+]

--- a/tests/cases/simple/patch/allof-to-oneof.json
+++ b/tests/cases/simple/patch/allof-to-oneof.json
@@ -1,0 +1,14 @@
+[
+  {
+    "op": "replace",
+    "path": "/components/schemas/GreetingResponse/properties/via_allof",
+    "value": {
+      "description": "Via oneOf.",
+      "oneOf": [
+        {
+          "$ref": "#/components/schemas/SubType"
+        }
+      ]
+    }
+  }
+]

--- a/tests/cases/simple/patch/allof-to-ref-with-type-change.json
+++ b/tests/cases/simple/patch/allof-to-ref-with-type-change.json
@@ -1,0 +1,16 @@
+[
+  {
+    "op": "replace",
+    "path": "/components/schemas/GreetingResponse/properties/via_allof",
+    "value": {
+      "$ref": "#/components/schemas/SubType"
+    }
+  },
+  {
+    "op": "add",
+    "path": "/components/schemas/SubType/properties/extra",
+    "value": {
+      "type": "integer"
+    }
+  }
+]

--- a/tests/cases/simple/patch/allof-to-ref.json
+++ b/tests/cases/simple/patch/allof-to-ref.json
@@ -1,0 +1,9 @@
+[
+  {
+    "op": "replace",
+    "path": "/components/schemas/GreetingResponse/properties/via_allof",
+    "value": {
+      "$ref": "#/components/schemas/SubType"
+    }
+  }
+]

--- a/tests/cases/simple/patch/anyof-to-allof.json
+++ b/tests/cases/simple/patch/anyof-to-allof.json
@@ -1,0 +1,14 @@
+[
+  {
+    "op": "replace",
+    "path": "/components/schemas/GreetingResponse/properties/via_anyof",
+    "value": {
+      "description": "Via allOf.",
+      "allOf": [
+        {
+          "$ref": "#/components/schemas/SubType"
+        }
+      ]
+    }
+  }
+]

--- a/tests/cases/simple/patch/anyof-to-oneof.json
+++ b/tests/cases/simple/patch/anyof-to-oneof.json
@@ -1,0 +1,14 @@
+[
+  {
+    "op": "replace",
+    "path": "/components/schemas/GreetingResponse/properties/via_anyof",
+    "value": {
+      "description": "Via oneOf.",
+      "oneOf": [
+        {
+          "$ref": "#/components/schemas/SubType"
+        }
+      ]
+    }
+  }
+]

--- a/tests/cases/simple/patch/anyof-to-ref.json
+++ b/tests/cases/simple/patch/anyof-to-ref.json
@@ -1,0 +1,9 @@
+[
+  {
+    "op": "replace",
+    "path": "/components/schemas/GreetingResponse/properties/via_anyof",
+    "value": {
+      "$ref": "#/components/schemas/SubType"
+    }
+  }
+]

--- a/tests/cases/simple/patch/inline-to-allof.json
+++ b/tests/cases/simple/patch/inline-to-allof.json
@@ -1,0 +1,14 @@
+[
+  {
+    "op": "replace",
+    "path": "/paths/~1hello~1{name}/get/parameters/0/schema",
+    "value": {
+      "description": "A string parameter",
+      "allOf": [
+        {
+          "type": "string"
+        }
+      ]
+    }
+  }
+]

--- a/tests/cases/simple/patch/not-inner-to-allof.json
+++ b/tests/cases/simple/patch/not-inner-to-allof.json
@@ -1,0 +1,16 @@
+[
+  {
+    "op": "replace",
+    "path": "/components/schemas/GreetingResponse/properties/not_a_number",
+    "value": {
+      "not": {
+        "description": "A number type",
+        "allOf": [
+          {
+            "type": "number"
+          }
+        ]
+      }
+    }
+  }
+]

--- a/tests/cases/simple/patch/not-to-allof.json
+++ b/tests/cases/simple/patch/not-to-allof.json
@@ -1,0 +1,16 @@
+[
+  {
+    "op": "replace",
+    "path": "/components/schemas/GreetingResponse/properties/not_a_number",
+    "value": {
+      "description": "Not a number, wrapped in allOf",
+      "allOf": [
+        {
+          "not": {
+            "type": "number"
+          }
+        }
+      ]
+    }
+  }
+]

--- a/tests/cases/simple/patch/oneof-to-allof.json
+++ b/tests/cases/simple/patch/oneof-to-allof.json
@@ -1,0 +1,14 @@
+[
+  {
+    "op": "replace",
+    "path": "/components/schemas/GreetingResponse/properties/via_oneof",
+    "value": {
+      "description": "Via allOf.",
+      "allOf": [
+        {
+          "$ref": "#/components/schemas/SubType"
+        }
+      ]
+    }
+  }
+]

--- a/tests/cases/simple/patch/oneof-to-anyof.json
+++ b/tests/cases/simple/patch/oneof-to-anyof.json
@@ -1,0 +1,14 @@
+[
+  {
+    "op": "replace",
+    "path": "/components/schemas/GreetingResponse/properties/via_oneof",
+    "value": {
+      "description": "Via anyOf.",
+      "anyOf": [
+        {
+          "$ref": "#/components/schemas/SubType"
+        }
+      ]
+    }
+  }
+]

--- a/tests/cases/simple/patch/oneof-to-ref.json
+++ b/tests/cases/simple/patch/oneof-to-ref.json
@@ -1,0 +1,9 @@
+[
+  {
+    "op": "replace",
+    "path": "/components/schemas/GreetingResponse/properties/via_oneof",
+    "value": {
+      "$ref": "#/components/schemas/SubType"
+    }
+  }
+]

--- a/tests/cases/simple/patch/ref-to-allof.json
+++ b/tests/cases/simple/patch/ref-to-allof.json
@@ -1,0 +1,14 @@
+[
+  {
+    "op": "replace",
+    "path": "/components/schemas/GreetingResponse/properties/via_ref",
+    "value": {
+      "description": "Via allOf.",
+      "allOf": [
+        {
+          "$ref": "#/components/schemas/SubType"
+        }
+      ]
+    }
+  }
+]

--- a/tests/cases/simple/patch/ref-to-anyof.json
+++ b/tests/cases/simple/patch/ref-to-anyof.json
@@ -1,0 +1,14 @@
+[
+  {
+    "op": "replace",
+    "path": "/components/schemas/GreetingResponse/properties/via_ref",
+    "value": {
+      "description": "Via anyOf.",
+      "anyOf": [
+        {
+          "$ref": "#/components/schemas/SubType"
+        }
+      ]
+    }
+  }
+]

--- a/tests/cases/simple/patch/ref-to-inline-allof.json
+++ b/tests/cases/simple/patch/ref-to-inline-allof.json
@@ -1,0 +1,20 @@
+[
+  {
+    "op": "replace",
+    "path": "/components/schemas/GreetingResponse/properties/via_ref",
+    "value": {
+      "description": "A greeting response",
+      "allOf": [
+        {
+          "type": "object",
+          "description": "Greeting response type",
+          "properties": {
+            "value": {
+              "type": "string"
+            }
+          }
+        }
+      ]
+    }
+  }
+]

--- a/tests/cases/simple/patch/ref-to-oneof.json
+++ b/tests/cases/simple/patch/ref-to-oneof.json
@@ -1,0 +1,14 @@
+[
+  {
+    "op": "replace",
+    "path": "/components/schemas/GreetingResponse/properties/via_ref",
+    "value": {
+      "description": "Via oneOf.",
+      "oneOf": [
+        {
+          "$ref": "#/components/schemas/SubType"
+        }
+      ]
+    }
+  }
+]

--- a/tests/cases/simple/patch/wrapper-unchanged-with-type-change.json
+++ b/tests/cases/simple/patch/wrapper-unchanged-with-type-change.json
@@ -1,0 +1,7 @@
+[
+  {
+    "op": "replace",
+    "path": "/components/schemas/SubType/properties/value/type",
+    "value": "integer"
+  }
+]


### PR DESCRIPTION
Previously, if an element changed between:

* a single-element `anyOf`, `allOf`, or `oneOf`
* a bare reference

Then, we wouldn't be able to tell that they were semantically equivalent. (This kind of change can occur if a doc comment gets added or goes away.)

Fix this by unwrapping single-element wrappers, drilling through them to compare the underlying refs.

Also add some debugging info I found useful.
