### PR TITLE
[1/7] extend base.json and add operation/parameter tests

### DIFF
--- a/tests/cases/simple/base.json
+++ b/tests/cases/simple/base.json
@@ -110,6 +110,77 @@
           }
         }
       }
+    },
+    "/unnamed": {
+      "get": {
+        "summary": "Unnamed operation",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/with-header": {
+      "get": {
+        "operationId": "with_header",
+        "summary": "Operation with header and cookie params",
+        "parameters": [
+          {
+            "name": "X-Request-Id",
+            "in": "header",
+            "schema": {
+              "type": "string"
+            },
+            "required": true
+          },
+          {
+            "name": "session",
+            "in": "cookie",
+            "schema": {
+              "type": "string"
+            },
+            "required": false
+          }
+        ],
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    },
+    "/with-default": {
+      "get": {
+        "operationId": "with_default",
+        "summary": "Operation with default response",
+        "responses": {
+          "200": {
+            "description": "Success"
+          },
+          "default": {
+            "description": "Error response",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/ErrorResponse"
+                }
+              }
+            }
+          }
+        }
+      }
+    },
+    "/no-body": {
+      "post": {
+        "operationId": "no_body",
+        "summary": "POST without request body",
+        "responses": {
+          "204": {
+            "description": "No content"
+          }
+        }
+      }
     }
   },
   "components": {
@@ -193,6 +264,95 @@
             "type": "string"
           }
         }
+      },
+      "ErrorResponse": {
+        "type": "object",
+        "properties": {
+          "message": {
+            "type": "string"
+          },
+          "code": {
+            "type": "integer"
+          }
+        },
+        "required": ["message", "code"]
+      },
+      "ArrayWithConstraints": {
+        "type": "array",
+        "items": {
+          "type": "string"
+        },
+        "minItems": 1,
+        "maxItems": 10,
+        "uniqueItems": false
+      },
+      "ObjectWithConstraints": {
+        "type": "object",
+        "minProperties": 1,
+        "maxProperties": 5,
+        "additionalProperties": {
+          "type": "string"
+        }
+      },
+      "MultiOneOf": {
+        "oneOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "integer"
+          }
+        ]
+      },
+      "MultiAllOf": {
+        "allOf": [
+          {
+            "type": "object",
+            "properties": {
+              "id": {
+                "type": "string"
+              }
+            }
+          },
+          {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              }
+            }
+          }
+        ]
+      },
+      "AnyOfExample": {
+        "anyOf": [
+          {
+            "type": "string"
+          },
+          {
+            "type": "number"
+          }
+        ]
+      },
+      "TypedProperties": {
+        "type": "object",
+        "properties": {
+          "count": {
+            "type": "integer"
+          },
+          "enabled": {
+            "type": "boolean"
+          },
+          "ratio": {
+            "type": "number"
+          }
+        }
+      },
+      "RefChainA": {
+        "$ref": "#/components/schemas/RefChainB"
+      },
+      "RefChainB": {
+        "$ref": "#/components/schemas/SubType"
       }
     }
   }

--- a/tests/cases/simple/output/add-cookie-parameter.out
+++ b/tests/cases/simple/output/add-cookie-parameter.out
@@ -1,0 +1,36 @@
+--- add-cookie-parameter.json
++++ patched
+@@ -275,6 +275,16 @@
+       "get": {
+         "description": "A simple ping endpoint that does nothing.",
+         "operationId": "ping",
++        "parameters": [
++          {
++            "in": "cookie",
++            "name": "tracking",
++            "required": false,
++            "schema": {
++              "type": "string"
++            }
++          }
++        ],
+         "responses": {
+           "200": {
+             "description": "Ping successful"
+
+
+Result for patch:
+[
+    Change {
+        message: "A new, optional parameter 'tracking' was added",
+        old_path: [
+            "#/paths/~1ping/get",
+        ],
+        new_path: [
+            "#/paths/~1ping/get/parameters/0",
+        ],
+        comparison: Input,
+        class: ForwardIncompatible,
+        details: Added,
+    },
+]

--- a/tests/cases/simple/output/add-header-parameter.out
+++ b/tests/cases/simple/output/add-header-parameter.out
@@ -1,0 +1,36 @@
+--- add-header-parameter.json
++++ patched
+@@ -275,6 +275,16 @@
+       "get": {
+         "description": "A simple ping endpoint that does nothing.",
+         "operationId": "ping",
++        "parameters": [
++          {
++            "in": "header",
++            "name": "X-Trace-Id",
++            "required": false,
++            "schema": {
++              "type": "string"
++            }
++          }
++        ],
+         "responses": {
+           "200": {
+             "description": "Ping successful"
+
+
+Result for patch:
+[
+    Change {
+        message: "A new, optional parameter 'X-Trace-Id' was added",
+        old_path: [
+            "#/paths/~1ping/get",
+        ],
+        new_path: [
+            "#/paths/~1ping/get/parameters/0",
+        ],
+        comparison: Input,
+        class: ForwardIncompatible,
+        details: Added,
+    },
+]

--- a/tests/cases/simple/output/add-operation-with-id.out
+++ b/tests/cases/simple/output/add-operation-with-id.out
@@ -1,0 +1,37 @@
+--- add-operation-with-id.json
++++ patched
+@@ -260,6 +260,17 @@
+         "summary": "Update an item"
+       }
+     },
++    "/new-endpoint": {
++      "get": {
++        "operationId": "new_endpoint",
++        "responses": {
++          "200": {
++            "description": "Success"
++          }
++        },
++        "summary": "New endpoint with explicit operationId"
++      }
++    },
+     "/no-body": {
+       "post": {
+         "operationId": "no_body",
+
+
+Result for patch:
+[
+    Change {
+        message: "The operation new_endpoint was added",
+        old_path: [
+            "#/paths",
+        ],
+        new_path: [
+            "#/paths/~1new-endpoint/get",
+        ],
+        comparison: Structural,
+        class: ForwardIncompatible,
+        details: Added,
+    },
+]

--- a/tests/cases/simple/output/add-operation.out
+++ b/tests/cases/simple/output/add-operation.out
@@ -1,6 +1,6 @@
 --- add-operation.json
 +++ patched
-@@ -92,6 +92,16 @@
+@@ -184,6 +184,16 @@
    },
    "openapi": "3.0.0",
    "paths": {

--- a/tests/cases/simple/output/add-optional-parameter.out
+++ b/tests/cases/simple/output/add-optional-parameter.out
@@ -1,6 +1,6 @@
 --- add-optional-parameter.json
 +++ patched
-@@ -111,6 +111,15 @@
+@@ -203,6 +203,15 @@
              "schema": {
                "type": "string"
              }

--- a/tests/cases/simple/output/add-required-parameter.out
+++ b/tests/cases/simple/output/add-required-parameter.out
@@ -1,6 +1,6 @@
 --- add-required-parameter.json
 +++ patched
-@@ -111,6 +111,15 @@
+@@ -203,6 +203,15 @@
              "schema": {
                "type": "string"
              }

--- a/tests/cases/simple/output/add-type-extension.out
+++ b/tests/cases/simple/output/add-type-extension.out
@@ -1,6 +1,6 @@
 --- add-type-extension.json
 +++ patched
-@@ -54,7 +54,10 @@
+@@ -88,7 +88,10 @@
          "required": [
            "message"
          ],
@@ -10,8 +10,8 @@
 +          "mumble": "frotz"
 +        }
        },
-       "SubType": {
-         "properties": {
+       "MultiAllOf": {
+         "allOf": [
 
 
 Result for patch:

--- a/tests/cases/simple/output/allof-to-anyof.out
+++ b/tests/cases/simple/output/allof-to-anyof.out
@@ -1,6 +1,6 @@
 --- allof-to-anyof.json
 +++ patched
-@@ -24,12 +24,12 @@
+@@ -58,12 +58,12 @@
              }
            },
            "via_allof": {

--- a/tests/cases/simple/output/allof-to-oneof-with-type-change.out
+++ b/tests/cases/simple/output/allof-to-oneof-with-type-change.out
@@ -1,6 +1,6 @@
 --- allof-to-oneof-with-type-change.json
 +++ patched
-@@ -24,12 +24,12 @@
+@@ -58,12 +58,12 @@
              }
            },
            "via_allof": {
@@ -16,7 +16,7 @@
            },
            "via_anyof": {
              "anyOf": [
-@@ -59,7 +59,7 @@
+@@ -137,7 +137,7 @@
        "SubType": {
          "properties": {
            "value": {

--- a/tests/cases/simple/output/allof-to-oneof.out
+++ b/tests/cases/simple/output/allof-to-oneof.out
@@ -1,6 +1,6 @@
 --- allof-to-oneof.json
 +++ patched
-@@ -24,12 +24,12 @@
+@@ -58,12 +58,12 @@
              }
            },
            "via_allof": {

--- a/tests/cases/simple/output/allof-to-ref-with-type-change.out
+++ b/tests/cases/simple/output/allof-to-ref-with-type-change.out
@@ -1,6 +1,6 @@
 --- allof-to-ref-with-type-change.json
 +++ patched
-@@ -24,12 +24,7 @@
+@@ -58,12 +58,7 @@
              }
            },
            "via_allof": {
@@ -14,7 +14,7 @@
            },
            "via_anyof": {
              "anyOf": [
-@@ -58,6 +53,9 @@
+@@ -136,6 +131,9 @@
        },
        "SubType": {
          "properties": {

--- a/tests/cases/simple/output/allof-to-ref.out
+++ b/tests/cases/simple/output/allof-to-ref.out
@@ -1,6 +1,6 @@
 --- allof-to-ref.json
 +++ patched
-@@ -24,12 +24,7 @@
+@@ -58,12 +58,7 @@
              }
            },
            "via_allof": {

--- a/tests/cases/simple/output/anyof-to-allof.out
+++ b/tests/cases/simple/output/anyof-to-allof.out
@@ -1,6 +1,6 @@
 --- anyof-to-allof.json
 +++ patched
-@@ -32,12 +32,12 @@
+@@ -66,12 +66,12 @@
              "description": "Via allOf."
            },
            "via_anyof": {

--- a/tests/cases/simple/output/anyof-to-oneof.out
+++ b/tests/cases/simple/output/anyof-to-oneof.out
@@ -1,6 +1,6 @@
 --- anyof-to-oneof.json
 +++ patched
-@@ -32,12 +32,12 @@
+@@ -66,12 +66,12 @@
              "description": "Via allOf."
            },
            "via_anyof": {

--- a/tests/cases/simple/output/anyof-to-ref.out
+++ b/tests/cases/simple/output/anyof-to-ref.out
@@ -1,6 +1,6 @@
 --- anyof-to-ref.json
 +++ patched
-@@ -32,12 +32,7 @@
+@@ -66,12 +66,7 @@
              "description": "Via allOf."
            },
            "via_anyof": {

--- a/tests/cases/simple/output/body-description-change.out
+++ b/tests/cases/simple/output/body-description-change.out
@@ -1,6 +1,6 @@
 --- body-description-change.json
 +++ patched
-@@ -139,6 +139,7 @@
+@@ -231,6 +231,7 @@
                }
              }
            },

--- a/tests/cases/simple/output/body-extension-change.out
+++ b/tests/cases/simple/output/body-extension-change.out
@@ -1,6 +1,6 @@
 --- body-extension-change.json
 +++ patched
-@@ -139,7 +139,8 @@
+@@ -231,7 +231,8 @@
                }
              }
            },

--- a/tests/cases/simple/output/body-optional-to-required.out
+++ b/tests/cases/simple/output/body-optional-to-required.out
@@ -1,6 +1,6 @@
 --- body-optional-to-required.json
 +++ patched
-@@ -158,7 +158,7 @@
+@@ -250,7 +250,7 @@
                }
              }
            },

--- a/tests/cases/simple/output/body-required-to-optional.out
+++ b/tests/cases/simple/output/body-required-to-optional.out
@@ -1,6 +1,6 @@
 --- body-required-to-optional.json
 +++ patched
-@@ -139,7 +139,7 @@
+@@ -231,7 +231,7 @@
                }
              }
            },

--- a/tests/cases/simple/output/change-header-parameter.out
+++ b/tests/cases/simple/output/change-header-parameter.out
@@ -1,14 +1,14 @@
---- change-operation-parameter-type.json
+--- change-header-parameter.json
 +++ patched
-@@ -201,7 +201,7 @@
-             "name": "language",
-             "required": false,
+@@ -340,7 +340,7 @@
+             "name": "X-Request-Id",
+             "required": true,
              "schema": {
 -              "type": "string"
 +              "type": "integer"
              }
-           }
-         ],
+           },
+           {
 
 
 Result for patch:
@@ -16,10 +16,10 @@ Result for patch:
     Change {
         message: "schema types changed",
         old_path: [
-            "#/paths/~1hello~1{name}/get/parameters/1/schema",
+            "#/paths/~1with-header/get/parameters/0/schema",
         ],
         new_path: [
-            "#/paths/~1hello~1{name}/get/parameters/1/schema",
+            "#/paths/~1with-header/get/parameters/0/schema",
         ],
         comparison: Input,
         class: Incompatible,

--- a/tests/cases/simple/output/change-operation-parameter-requirement.out
+++ b/tests/cases/simple/output/change-operation-parameter-requirement.out
@@ -1,6 +1,6 @@
 --- change-operation-parameter-requirement.json
 +++ patched
-@@ -107,7 +107,7 @@
+@@ -199,7 +199,7 @@
              "description": "Language for the greeting",
              "in": "query",
              "name": "language",

--- a/tests/cases/simple/output/change-property-type.out
+++ b/tests/cases/simple/output/change-property-type.out
@@ -1,6 +1,6 @@
 --- change-property-type.json
 +++ patched
-@@ -16,7 +16,7 @@
+@@ -50,7 +50,7 @@
          "properties": {
            "message": {
              "description": "The greeting message",

--- a/tests/cases/simple/output/inline-to-allof.out
+++ b/tests/cases/simple/output/inline-to-allof.out
@@ -1,6 +1,6 @@
 --- inline-to-allof.json
 +++ patched
-@@ -100,7 +100,12 @@
+@@ -192,7 +192,12 @@
              "in": "path",
              "name": "name",
              "schema": {

--- a/tests/cases/simple/output/modify-cycle-type.out
+++ b/tests/cases/simple/output/modify-cycle-type.out
@@ -1,6 +1,6 @@
 --- modify-cycle-type.json
 +++ patched
-@@ -67,10 +67,7 @@
+@@ -145,10 +145,7 @@
        "Tree": {
          "properties": {
            "children": {

--- a/tests/cases/simple/output/not-inner-to-allof.out
+++ b/tests/cases/simple/output/not-inner-to-allof.out
@@ -1,6 +1,6 @@
 --- not-inner-to-allof.json
 +++ patched
-@@ -20,7 +20,12 @@
+@@ -54,7 +54,12 @@
            },
            "not_a_number": {
              "not": {

--- a/tests/cases/simple/output/not-to-allof.out
+++ b/tests/cases/simple/output/not-to-allof.out
@@ -1,6 +1,6 @@
 --- not-to-allof.json
 +++ patched
-@@ -19,9 +19,14 @@
+@@ -53,9 +53,14 @@
              "type": "string"
            },
            "not_a_number": {

--- a/tests/cases/simple/output/oneof-to-allof.out
+++ b/tests/cases/simple/output/oneof-to-allof.out
@@ -1,6 +1,6 @@
 --- oneof-to-allof.json
 +++ patched
-@@ -40,12 +40,12 @@
+@@ -74,12 +74,12 @@
              "description": "Via anyOf."
            },
            "via_oneof": {

--- a/tests/cases/simple/output/oneof-to-anyof.out
+++ b/tests/cases/simple/output/oneof-to-anyof.out
@@ -1,6 +1,6 @@
 --- oneof-to-anyof.json
 +++ patched
-@@ -40,12 +40,12 @@
+@@ -74,12 +74,12 @@
              "description": "Via anyOf."
            },
            "via_oneof": {

--- a/tests/cases/simple/output/oneof-to-ref.out
+++ b/tests/cases/simple/output/oneof-to-ref.out
@@ -1,6 +1,6 @@
 --- oneof-to-ref.json
 +++ patched
-@@ -40,12 +40,7 @@
+@@ -74,12 +74,7 @@
              "description": "Via anyOf."
            },
            "via_oneof": {

--- a/tests/cases/simple/output/param-required-to-optional.out
+++ b/tests/cases/simple/output/param-required-to-optional.out
@@ -1,0 +1,28 @@
+--- param-required-to-optional.json
++++ patched
+@@ -338,7 +338,7 @@
+           {
+             "in": "header",
+             "name": "X-Request-Id",
+-            "required": true,
++            "required": false,
+             "schema": {
+               "type": "string"
+             }
+
+
+Result for patch:
+[
+    Change {
+        message: "The parameter 'X-Request-Id' was required and is now optional",
+        old_path: [
+            "#/paths/~1with-header/get/parameters/0",
+        ],
+        new_path: [
+            "#/paths/~1with-header/get/parameters/0",
+        ],
+        comparison: Input,
+        class: ForwardIncompatible,
+        details: LessStrict,
+    },
+]

--- a/tests/cases/simple/output/ref-to-allof.out
+++ b/tests/cases/simple/output/ref-to-allof.out
@@ -1,6 +1,6 @@
 --- ref-to-allof.json
 +++ patched
-@@ -48,7 +48,12 @@
+@@ -82,7 +82,12 @@
              ]
            },
            "via_ref": {

--- a/tests/cases/simple/output/ref-to-anyof.out
+++ b/tests/cases/simple/output/ref-to-anyof.out
@@ -1,6 +1,6 @@
 --- ref-to-anyof.json
 +++ patched
-@@ -48,7 +48,12 @@
+@@ -82,7 +82,12 @@
              ]
            },
            "via_ref": {

--- a/tests/cases/simple/output/ref-to-inline-allof.out
+++ b/tests/cases/simple/output/ref-to-inline-allof.out
@@ -1,6 +1,6 @@
 --- ref-to-inline-allof.json
 +++ patched
-@@ -48,7 +48,18 @@
+@@ -82,7 +82,18 @@
              ]
            },
            "via_ref": {

--- a/tests/cases/simple/output/ref-to-oneof.out
+++ b/tests/cases/simple/output/ref-to-oneof.out
@@ -1,6 +1,6 @@
 --- ref-to-oneof.json
 +++ patched
-@@ -48,7 +48,12 @@
+@@ -82,7 +82,12 @@
              ]
            },
            "via_ref": {

--- a/tests/cases/simple/output/remove-header-parameter.out
+++ b/tests/cases/simple/output/remove-header-parameter.out
@@ -1,0 +1,34 @@
+--- remove-header-parameter.json
++++ patched
+@@ -336,14 +336,6 @@
+         "operationId": "with_header",
+         "parameters": [
+           {
+-            "in": "header",
+-            "name": "X-Request-Id",
+-            "required": true,
+-            "schema": {
+-              "type": "string"
+-            }
+-          },
+-          {
+             "in": "cookie",
+             "name": "session",
+             "required": false,
+
+
+Result for patch:
+[
+    Change {
+        message: "The parameter 'X-Request-Id' was removed",
+        old_path: [
+            "#/paths/~1with-header/get/parameters/0",
+        ],
+        new_path: [
+            "#/paths/~1with-header/get",
+        ],
+        comparison: Input,
+        class: BackwardIncompatible,
+        details: Removed,
+    },
+]

--- a/tests/cases/simple/output/remove-operation-parameter.out
+++ b/tests/cases/simple/output/remove-operation-parameter.out
@@ -1,6 +1,6 @@
 --- remove-operation-parameter.json
 +++ patched
-@@ -102,15 +102,6 @@
+@@ -194,15 +194,6 @@
              "schema": {
                "type": "string"
              }

--- a/tests/cases/simple/output/remove-operation.out
+++ b/tests/cases/simple/output/remove-operation.out
@@ -1,7 +1,7 @@
 --- remove-operation.json
 +++ patched
-@@ -168,18 +168,7 @@
-         "summary": "Update an item"
+@@ -271,18 +271,7 @@
+         "summary": "POST without request body"
        }
      },
 -    "/ping": {

--- a/tests/cases/simple/output/remove-required-body.out
+++ b/tests/cases/simple/output/remove-required-body.out
@@ -1,6 +1,6 @@
 --- remove-required-body.json
 +++ patched
-@@ -131,16 +131,6 @@
+@@ -223,16 +223,6 @@
      "/items": {
        "post": {
          "operationId": "create_item",

--- a/tests/cases/simple/output/remove-unnamed-operation.out
+++ b/tests/cases/simple/output/remove-unnamed-operation.out
@@ -1,0 +1,36 @@
+--- remove-unnamed-operation.json
++++ patched
+@@ -300,16 +300,6 @@
+         "summary": "Get a tree structure"
+       }
+     },
+-    "/unnamed": {
+-      "get": {
+-        "responses": {
+-          "200": {
+-            "description": "Success"
+-          }
+-        },
+-        "summary": "Unnamed operation"
+-      }
+-    },
+     "/with-default": {
+       "get": {
+         "operationId": "with_default",
+
+
+Result for patch:
+[
+    Change {
+        message: "The operation <unnamed> was removed",
+        old_path: [
+            "#/paths/~1unnamed/get",
+        ],
+        new_path: [
+            "#/paths",
+        ],
+        comparison: Structural,
+        class: BackwardIncompatible,
+        details: Removed,
+    },
+]

--- a/tests/cases/simple/output/type-indirection.out
+++ b/tests/cases/simple/output/type-indirection.out
@@ -1,6 +1,6 @@
 --- type-indirection.json
 +++ patched
-@@ -15,8 +15,7 @@
+@@ -49,8 +49,7 @@
        "GreetingResponse": {
          "properties": {
            "message": {
@@ -10,7 +10,7 @@
            },
            "not_a_number": {
              "not": {
-@@ -56,6 +55,13 @@
+@@ -90,6 +89,13 @@
          ],
          "type": "object"
        },
@@ -21,9 +21,9 @@
 +          "jank": true
 +        }
 +      },
-       "SubType": {
-         "properties": {
-           "value": {
+       "MultiAllOf": {
+         "allOf": [
+           {
 
 
 Result for patch:

--- a/tests/cases/simple/output/type-rename.out
+++ b/tests/cases/simple/output/type-rename.out
@@ -1,6 +1,6 @@
 --- type-rename.json
 +++ patched
-@@ -12,7 +12,7 @@
+@@ -46,7 +46,7 @@
          ],
          "type": "object"
        },
@@ -9,7 +9,7 @@
          "properties": {
            "message": {
              "description": "The greeting message",
-@@ -118,7 +118,7 @@
+@@ -210,7 +210,7 @@
              "content": {
                "application/json": {
                  "schema": {

--- a/tests/cases/simple/output/unhandled-add-prop.out
+++ b/tests/cases/simple/output/unhandled-add-prop.out
@@ -1,6 +1,6 @@
 --- unhandled-add-prop.json
 +++ patched
-@@ -23,6 +23,10 @@
+@@ -57,6 +57,10 @@
                "type": "number"
              }
            },
@@ -11,7 +11,7 @@
            "via_allof": {
              "allOf": [
                {
-@@ -52,7 +56,8 @@
+@@ -86,7 +90,8 @@
            }
          },
          "required": [

--- a/tests/cases/simple/output/wrapper-unchanged-with-type-change.out
+++ b/tests/cases/simple/output/wrapper-unchanged-with-type-change.out
@@ -1,6 +1,6 @@
 --- wrapper-unchanged-with-type-change.json
 +++ patched
-@@ -59,7 +59,7 @@
+@@ -137,7 +137,7 @@
        "SubType": {
          "properties": {
            "value": {

--- a/tests/cases/simple/patch/add-cookie-parameter.json
+++ b/tests/cases/simple/patch/add-cookie-parameter.json
@@ -1,0 +1,16 @@
+[
+  {
+    "op": "add",
+    "path": "/paths/~1ping/get/parameters",
+    "value": [
+      {
+        "name": "tracking",
+        "in": "cookie",
+        "schema": {
+          "type": "string"
+        },
+        "required": false
+      }
+    ]
+  }
+]

--- a/tests/cases/simple/patch/add-header-parameter.json
+++ b/tests/cases/simple/patch/add-header-parameter.json
@@ -1,0 +1,16 @@
+[
+  {
+    "op": "add",
+    "path": "/paths/~1ping/get/parameters",
+    "value": [
+      {
+        "name": "X-Trace-Id",
+        "in": "header",
+        "schema": {
+          "type": "string"
+        },
+        "required": false
+      }
+    ]
+  }
+]

--- a/tests/cases/simple/patch/add-operation-with-id.json
+++ b/tests/cases/simple/patch/add-operation-with-id.json
@@ -1,0 +1,17 @@
+[
+  {
+    "op": "add",
+    "path": "/paths/~1new-endpoint",
+    "value": {
+      "get": {
+        "operationId": "new_endpoint",
+        "summary": "New endpoint with explicit operationId",
+        "responses": {
+          "200": {
+            "description": "Success"
+          }
+        }
+      }
+    }
+  }
+]

--- a/tests/cases/simple/patch/change-header-parameter.json
+++ b/tests/cases/simple/patch/change-header-parameter.json
@@ -1,0 +1,7 @@
+[
+  {
+    "op": "replace",
+    "path": "/paths/~1with-header/get/parameters/0/schema/type",
+    "value": "integer"
+  }
+]

--- a/tests/cases/simple/patch/param-required-to-optional.json
+++ b/tests/cases/simple/patch/param-required-to-optional.json
@@ -1,0 +1,7 @@
+[
+  {
+    "op": "replace",
+    "path": "/paths/~1with-header/get/parameters/0/required",
+    "value": false
+  }
+]

--- a/tests/cases/simple/patch/remove-header-parameter.json
+++ b/tests/cases/simple/patch/remove-header-parameter.json
@@ -1,0 +1,6 @@
+[
+  {
+    "op": "remove",
+    "path": "/paths/~1with-header/get/parameters/0"
+  }
+]

--- a/tests/cases/simple/patch/remove-unnamed-operation.json
+++ b/tests/cases/simple/patch/remove-unnamed-operation.json
@@ -1,0 +1,6 @@
+[
+  {
+    "op": "remove",
+    "path": "/paths/~1unnamed"
+  }
+]


### PR DESCRIPTION
Add /unnamed, /with-header, /with-default, and /no-body endpoints along with new schema types. Add tests for header/cookie parameters, operationId handling, and parameter requirement transitions.
