### PR TITLE
[1/n] remove line numbers from patch output

### DIFF
--- a/tests/cases/simple/output/add-cookie-parameter.out
+++ b/tests/cases/simple/output/add-cookie-parameter.out
@@ -1,6 +1,6 @@
 --- add-cookie-parameter.json
 +++ patched
-@@ -365,6 +365,16 @@
+@@
        "get": {
          "description": "A simple ping endpoint that does nothing.",
          "operationId": "ping",

--- a/tests/cases/simple/output/add-default-response.out
+++ b/tests/cases/simple/output/add-default-response.out
@@ -1,6 +1,6 @@
 --- add-default-response.json
 +++ patched
-@@ -368,6 +368,16 @@
+@@
          "responses": {
            "200": {
              "description": "Ping successful"

--- a/tests/cases/simple/output/add-header-parameter.out
+++ b/tests/cases/simple/output/add-header-parameter.out
@@ -1,6 +1,6 @@
 --- add-header-parameter.json
 +++ patched
-@@ -365,6 +365,16 @@
+@@
        "get": {
          "description": "A simple ping endpoint that does nothing.",
          "operationId": "ping",

--- a/tests/cases/simple/output/add-operation-with-id.out
+++ b/tests/cases/simple/output/add-operation-with-id.out
@@ -1,6 +1,6 @@
 --- add-operation-with-id.json
 +++ patched
-@@ -314,6 +314,17 @@
+@@
          "summary": "Update an item"
        }
      },

--- a/tests/cases/simple/output/add-operation.out
+++ b/tests/cases/simple/output/add-operation.out
@@ -1,6 +1,6 @@
 --- add-operation.json
 +++ patched
-@@ -238,6 +238,16 @@
+@@
          "summary": "Get arrays"
        }
      },

--- a/tests/cases/simple/output/add-optional-body.out
+++ b/tests/cases/simple/output/add-optional-body.out
@@ -1,6 +1,6 @@
 --- add-optional-body.json
 +++ patched
-@@ -317,6 +317,21 @@
+@@
      "/no-body": {
        "post": {
          "operationId": "no_body",

--- a/tests/cases/simple/output/add-optional-parameter.out
+++ b/tests/cases/simple/output/add-optional-parameter.out
@@ -1,6 +1,6 @@
 --- add-optional-parameter.json
 +++ patched
-@@ -257,6 +257,15 @@
+@@
              "schema": {
                "type": "string"
              }

--- a/tests/cases/simple/output/add-required-body.out
+++ b/tests/cases/simple/output/add-required-body.out
@@ -1,6 +1,6 @@
 --- add-required-body.json
 +++ patched
-@@ -317,6 +317,21 @@
+@@
      "/no-body": {
        "post": {
          "operationId": "no_body",

--- a/tests/cases/simple/output/add-required-parameter.out
+++ b/tests/cases/simple/output/add-required-parameter.out
@@ -1,6 +1,6 @@
 --- add-required-parameter.json
 +++ patched
-@@ -257,6 +257,15 @@
+@@
              "schema": {
                "type": "string"
              }

--- a/tests/cases/simple/output/add-response-code.out
+++ b/tests/cases/simple/output/add-response-code.out
@@ -1,6 +1,6 @@
 --- add-response-code.json
 +++ patched
-@@ -368,6 +368,9 @@
+@@
          "responses": {
            "200": {
              "description": "Ping successful"

--- a/tests/cases/simple/output/add-type-extension.out
+++ b/tests/cases/simple/output/add-type-extension.out
@@ -1,6 +1,6 @@
 --- add-type-extension.json
 +++ patched
-@@ -88,7 +88,10 @@
+@@
          "required": [
            "message"
          ],

--- a/tests/cases/simple/output/allof-to-anyof.out
+++ b/tests/cases/simple/output/allof-to-anyof.out
@@ -1,6 +1,6 @@
 --- allof-to-anyof.json
 +++ patched
-@@ -58,12 +58,12 @@
+@@
              }
            },
            "via_allof": {

--- a/tests/cases/simple/output/allof-to-oneof-with-type-change.out
+++ b/tests/cases/simple/output/allof-to-oneof-with-type-change.out
@@ -1,6 +1,6 @@
 --- allof-to-oneof-with-type-change.json
 +++ patched
-@@ -58,12 +58,12 @@
+@@
              }
            },
            "via_allof": {
@@ -16,7 +16,7 @@
            },
            "via_anyof": {
              "anyOf": [
-@@ -137,7 +137,7 @@
+@@
        "SubType": {
          "properties": {
            "value": {

--- a/tests/cases/simple/output/allof-to-oneof.out
+++ b/tests/cases/simple/output/allof-to-oneof.out
@@ -1,6 +1,6 @@
 --- allof-to-oneof.json
 +++ patched
-@@ -58,12 +58,12 @@
+@@
              }
            },
            "via_allof": {

--- a/tests/cases/simple/output/allof-to-ref-with-type-change.out
+++ b/tests/cases/simple/output/allof-to-ref-with-type-change.out
@@ -1,6 +1,6 @@
 --- allof-to-ref-with-type-change.json
 +++ patched
-@@ -58,12 +58,7 @@
+@@
              }
            },
            "via_allof": {
@@ -14,7 +14,7 @@
            },
            "via_anyof": {
              "anyOf": [
-@@ -136,6 +131,9 @@
+@@
        },
        "SubType": {
          "properties": {

--- a/tests/cases/simple/output/allof-to-ref.out
+++ b/tests/cases/simple/output/allof-to-ref.out
@@ -1,6 +1,6 @@
 --- allof-to-ref.json
 +++ patched
-@@ -58,12 +58,7 @@
+@@
              }
            },
            "via_allof": {

--- a/tests/cases/simple/output/any-schema-change.out
+++ b/tests/cases/simple/output/any-schema-change.out
@@ -1,6 +1,6 @@
 --- any-schema-change.json
 +++ patched
-@@ -48,6 +48,7 @@
+@@
        },
        "GreetingResponse": {
          "properties": {

--- a/tests/cases/simple/output/anyof-to-allof.out
+++ b/tests/cases/simple/output/anyof-to-allof.out
@@ -1,6 +1,6 @@
 --- anyof-to-allof.json
 +++ patched
-@@ -66,12 +66,12 @@
+@@
              "description": "Via allOf."
            },
            "via_anyof": {

--- a/tests/cases/simple/output/anyof-to-oneof.out
+++ b/tests/cases/simple/output/anyof-to-oneof.out
@@ -1,6 +1,6 @@
 --- anyof-to-oneof.json
 +++ patched
-@@ -66,12 +66,12 @@
+@@
              "description": "Via allOf."
            },
            "via_anyof": {

--- a/tests/cases/simple/output/anyof-to-ref.out
+++ b/tests/cases/simple/output/anyof-to-ref.out
@@ -1,6 +1,6 @@
 --- anyof-to-ref.json
 +++ patched
-@@ -66,12 +66,7 @@
+@@
              "description": "Via allOf."
            },
            "via_anyof": {

--- a/tests/cases/simple/output/array-items-add.out
+++ b/tests/cases/simple/output/array-items-add.out
@@ -1,6 +1,6 @@
 --- array-items-add.json
 +++ patched
-@@ -12,9 +12,6 @@
+@@
          ]
        },
        "ArrayWithConstraints": {

--- a/tests/cases/simple/output/array-items-remove.out
+++ b/tests/cases/simple/output/array-items-remove.out
@@ -1,6 +1,6 @@
 --- array-items-remove.json
 +++ patched
-@@ -146,7 +146,7 @@
+@@
          "properties": {
            "children": {
              "items": {

--- a/tests/cases/simple/output/array-max-items-change.out
+++ b/tests/cases/simple/output/array-max-items-change.out
@@ -1,6 +1,6 @@
 --- array-max-items-change.json
 +++ patched
-@@ -15,7 +15,7 @@
+@@
          "items": {
            "type": "string"
          },

--- a/tests/cases/simple/output/array-min-items-change.out
+++ b/tests/cases/simple/output/array-min-items-change.out
@@ -1,6 +1,6 @@
 --- array-min-items-change.json
 +++ patched
-@@ -16,7 +16,7 @@
+@@
            "type": "string"
          },
          "maxItems": 10,

--- a/tests/cases/simple/output/array-unique-items-change.out
+++ b/tests/cases/simple/output/array-unique-items-change.out
@@ -1,6 +1,6 @@
 --- array-unique-items-change.json
 +++ patched
-@@ -18,7 +18,7 @@
+@@
          "maxItems": 10,
          "minItems": 1,
          "type": "array",

--- a/tests/cases/simple/output/body-description-change.out
+++ b/tests/cases/simple/output/body-description-change.out
@@ -1,6 +1,6 @@
 --- body-description-change.json
 +++ patched
-@@ -285,6 +285,7 @@
+@@
                }
              }
            },

--- a/tests/cases/simple/output/body-extension-change.out
+++ b/tests/cases/simple/output/body-extension-change.out
@@ -1,6 +1,6 @@
 --- body-extension-change.json
 +++ patched
-@@ -285,7 +285,8 @@
+@@
                }
              }
            },

--- a/tests/cases/simple/output/body-optional-to-required.out
+++ b/tests/cases/simple/output/body-optional-to-required.out
@@ -1,6 +1,6 @@
 --- body-optional-to-required.json
 +++ patched
-@@ -304,7 +304,7 @@
+@@
                }
              }
            },

--- a/tests/cases/simple/output/body-required-to-optional.out
+++ b/tests/cases/simple/output/body-required-to-optional.out
@@ -1,6 +1,6 @@
 --- body-required-to-optional.json
 +++ patched
-@@ -285,7 +285,7 @@
+@@
                }
              }
            },

--- a/tests/cases/simple/output/boolean-change.out
+++ b/tests/cases/simple/output/boolean-change.out
@@ -1,6 +1,6 @@
 --- boolean-change.json
 +++ patched
-@@ -159,6 +159,7 @@
+@@
              "type": "integer"
            },
            "enabled": {

--- a/tests/cases/simple/output/boolean-enum-change.out
+++ b/tests/cases/simple/output/boolean-enum-change.out
@@ -1,6 +1,6 @@
 --- boolean-enum-change.json
 +++ patched
-@@ -159,6 +159,9 @@
+@@
              "type": "integer"
            },
            "enabled": {

--- a/tests/cases/simple/output/change-default-response.out
+++ b/tests/cases/simple/output/change-default-response.out
@@ -1,6 +1,6 @@
 --- change-default-response.json
 +++ patched
-@@ -451,7 +451,7 @@
+@@
                  }
                }
              },

--- a/tests/cases/simple/output/change-header-parameter.out
+++ b/tests/cases/simple/output/change-header-parameter.out
@@ -1,6 +1,6 @@
 --- change-header-parameter.json
 +++ patched
-@@ -466,7 +466,7 @@
+@@
              "name": "X-Request-Id",
              "required": true,
              "schema": {

--- a/tests/cases/simple/output/change-operation-parameter-requirement.out
+++ b/tests/cases/simple/output/change-operation-parameter-requirement.out
@@ -1,6 +1,6 @@
 --- change-operation-parameter-requirement.json
 +++ patched
-@@ -253,7 +253,7 @@
+@@
              "description": "Language for the greeting",
              "in": "query",
              "name": "language",

--- a/tests/cases/simple/output/change-operation-parameter-type.out
+++ b/tests/cases/simple/output/change-operation-parameter-type.out
@@ -1,6 +1,6 @@
 --- change-operation-parameter-type.json
 +++ patched
-@@ -255,7 +255,7 @@
+@@
              "name": "language",
              "required": false,
              "schema": {

--- a/tests/cases/simple/output/change-property-type.out
+++ b/tests/cases/simple/output/change-property-type.out
@@ -1,6 +1,6 @@
 --- change-property-type.json
 +++ patched
-@@ -50,7 +50,7 @@
+@@
          "properties": {
            "message": {
              "description": "The greeting message",

--- a/tests/cases/simple/output/inline-to-allof.out
+++ b/tests/cases/simple/output/inline-to-allof.out
@@ -1,6 +1,6 @@
 --- inline-to-allof.json
 +++ patched
-@@ -246,7 +246,12 @@
+@@
              "in": "path",
              "name": "name",
              "schema": {

--- a/tests/cases/simple/output/integer-format-change.out
+++ b/tests/cases/simple/output/integer-format-change.out
@@ -1,6 +1,6 @@
 --- integer-format-change.json
 +++ patched
-@@ -156,6 +156,7 @@
+@@
        "TypedProperties": {
          "properties": {
            "count": {

--- a/tests/cases/simple/output/modify-cycle-type.out
+++ b/tests/cases/simple/output/modify-cycle-type.out
@@ -1,6 +1,6 @@
 --- modify-cycle-type.json
 +++ patched
-@@ -145,10 +145,7 @@
+@@
        "Tree": {
          "properties": {
            "children": {

--- a/tests/cases/simple/output/multi-allof-variant-change.out
+++ b/tests/cases/simple/output/multi-allof-variant-change.out
@@ -1,6 +1,6 @@
 --- multi-allof-variant-change.json
 +++ patched
-@@ -95,7 +95,7 @@
+@@
            {
              "properties": {
                "id": {

--- a/tests/cases/simple/output/multi-anyof-variant-change.out
+++ b/tests/cases/simple/output/multi-anyof-variant-change.out
@@ -1,6 +1,6 @@
 --- multi-anyof-variant-change.json
 +++ patched
-@@ -4,7 +4,7 @@
+@@
        "AnyOfExample": {
          "anyOf": [
            {

--- a/tests/cases/simple/output/multi-oneof-count-change.out
+++ b/tests/cases/simple/output/multi-oneof-count-change.out
@@ -1,6 +1,6 @@
 --- multi-oneof-count-change.json
 +++ patched
-@@ -117,6 +117,9 @@
+@@
            },
            {
              "type": "integer"

--- a/tests/cases/simple/output/multi-oneof-variant-change.out
+++ b/tests/cases/simple/output/multi-oneof-variant-change.out
@@ -1,6 +1,6 @@
 --- multi-oneof-variant-change.json
 +++ patched
-@@ -113,7 +113,7 @@
+@@
        "MultiOneOf": {
          "oneOf": [
            {

--- a/tests/cases/simple/output/not-inner-to-allof.out
+++ b/tests/cases/simple/output/not-inner-to-allof.out
@@ -1,6 +1,6 @@
 --- not-inner-to-allof.json
 +++ patched
-@@ -54,7 +54,12 @@
+@@
            },
            "not_a_number": {
              "not": {

--- a/tests/cases/simple/output/not-to-allof.out
+++ b/tests/cases/simple/output/not-to-allof.out
@@ -1,6 +1,6 @@
 --- not-to-allof.json
 +++ patched
-@@ -53,9 +53,14 @@
+@@
              "type": "string"
            },
            "not_a_number": {

--- a/tests/cases/simple/output/number-constraints-change.out
+++ b/tests/cases/simple/output/number-constraints-change.out
@@ -1,6 +1,6 @@
 --- number-constraints-change.json
 +++ patched
-@@ -162,6 +162,7 @@
+@@
              "type": "boolean"
            },
            "ratio": {

--- a/tests/cases/simple/output/object-additional-props-false.out
+++ b/tests/cases/simple/output/object-additional-props-false.out
@@ -1,6 +1,6 @@
 --- object-additional-props-false.json
 +++ patched
-@@ -121,9 +121,7 @@
+@@
          ]
        },
        "ObjectWithConstraints": {

--- a/tests/cases/simple/output/object-additional-props-schema-change.out
+++ b/tests/cases/simple/output/object-additional-props-schema-change.out
@@ -1,6 +1,6 @@
 --- object-additional-props-schema-change.json
 +++ patched
-@@ -122,7 +122,7 @@
+@@
        },
        "ObjectWithConstraints": {
          "additionalProperties": {

--- a/tests/cases/simple/output/object-additional-props-type-change.out
+++ b/tests/cases/simple/output/object-additional-props-type-change.out
@@ -1,6 +1,6 @@
 --- object-additional-props-type-change.json
 +++ patched
-@@ -121,9 +121,7 @@
+@@
          ]
        },
        "ObjectWithConstraints": {

--- a/tests/cases/simple/output/object-max-properties-change.out
+++ b/tests/cases/simple/output/object-max-properties-change.out
@@ -1,6 +1,6 @@
 --- object-max-properties-change.json
 +++ patched
-@@ -124,7 +124,7 @@
+@@
          "additionalProperties": {
            "type": "string"
          },

--- a/tests/cases/simple/output/object-min-properties-change.out
+++ b/tests/cases/simple/output/object-min-properties-change.out
@@ -1,6 +1,6 @@
 --- object-min-properties-change.json
 +++ patched
-@@ -125,7 +125,7 @@
+@@
            "type": "string"
          },
          "maxProperties": 5,

--- a/tests/cases/simple/output/oneof-to-allof.out
+++ b/tests/cases/simple/output/oneof-to-allof.out
@@ -1,6 +1,6 @@
 --- oneof-to-allof.json
 +++ patched
-@@ -74,12 +74,12 @@
+@@
              "description": "Via anyOf."
            },
            "via_oneof": {

--- a/tests/cases/simple/output/oneof-to-anyof.out
+++ b/tests/cases/simple/output/oneof-to-anyof.out
@@ -1,6 +1,6 @@
 --- oneof-to-anyof.json
 +++ patched
-@@ -74,12 +74,12 @@
+@@
              "description": "Via anyOf."
            },
            "via_oneof": {

--- a/tests/cases/simple/output/oneof-to-ref.out
+++ b/tests/cases/simple/output/oneof-to-ref.out
@@ -1,6 +1,6 @@
 --- oneof-to-ref.json
 +++ patched
-@@ -74,12 +74,7 @@
+@@
              "description": "Via anyOf."
            },
            "via_oneof": {

--- a/tests/cases/simple/output/param-required-to-optional.out
+++ b/tests/cases/simple/output/param-required-to-optional.out
@@ -1,6 +1,6 @@
 --- param-required-to-optional.json
 +++ patched
-@@ -464,7 +464,7 @@
+@@
            {
              "in": "header",
              "name": "X-Request-Id",

--- a/tests/cases/simple/output/param-schema-to-content.out
+++ b/tests/cases/simple/output/param-schema-to-content.out
@@ -1,6 +1,6 @@
 --- param-schema-to-content.json
 +++ patched
-@@ -250,13 +250,17 @@
+@@
              }
            },
            {

--- a/tests/cases/simple/output/ref-chain-change.out
+++ b/tests/cases/simple/output/ref-chain-change.out
@@ -1,6 +1,6 @@
 --- ref-chain-change.json
 +++ patched
-@@ -132,7 +132,7 @@
+@@
          "$ref": "#/components/schemas/RefChainB"
        },
        "RefChainB": {

--- a/tests/cases/simple/output/ref-to-allof.out
+++ b/tests/cases/simple/output/ref-to-allof.out
@@ -1,6 +1,6 @@
 --- ref-to-allof.json
 +++ patched
-@@ -82,7 +82,12 @@
+@@
              ]
            },
            "via_ref": {

--- a/tests/cases/simple/output/ref-to-anyof.out
+++ b/tests/cases/simple/output/ref-to-anyof.out
@@ -1,6 +1,6 @@
 --- ref-to-anyof.json
 +++ patched
-@@ -82,7 +82,12 @@
+@@
              ]
            },
            "via_ref": {

--- a/tests/cases/simple/output/ref-to-inline-allof.out
+++ b/tests/cases/simple/output/ref-to-inline-allof.out
@@ -1,6 +1,6 @@
 --- ref-to-inline-allof.json
 +++ patched
-@@ -82,7 +82,18 @@
+@@
              ]
            },
            "via_ref": {

--- a/tests/cases/simple/output/ref-to-oneof.out
+++ b/tests/cases/simple/output/ref-to-oneof.out
@@ -1,6 +1,6 @@
 --- ref-to-oneof.json
 +++ patched
-@@ -82,7 +82,12 @@
+@@
              ]
            },
            "via_ref": {

--- a/tests/cases/simple/output/remove-default-response.out
+++ b/tests/cases/simple/output/remove-default-response.out
@@ -1,6 +1,6 @@
 --- remove-default-response.json
 +++ patched
-@@ -442,16 +442,6 @@
+@@
          "responses": {
            "200": {
              "description": "Success"

--- a/tests/cases/simple/output/remove-header-parameter.out
+++ b/tests/cases/simple/output/remove-header-parameter.out
@@ -1,6 +1,6 @@
 --- remove-header-parameter.json
 +++ patched
-@@ -462,14 +462,6 @@
+@@
          "operationId": "with_header",
          "parameters": [
            {

--- a/tests/cases/simple/output/remove-operation-parameter.out
+++ b/tests/cases/simple/output/remove-operation-parameter.out
@@ -1,6 +1,6 @@
 --- remove-operation-parameter.json
 +++ patched
-@@ -248,15 +248,6 @@
+@@
              "schema": {
                "type": "string"
              }

--- a/tests/cases/simple/output/remove-operation.out
+++ b/tests/cases/simple/output/remove-operation.out
@@ -1,6 +1,6 @@
 --- remove-operation.json
 +++ patched
-@@ -361,18 +361,7 @@
+@@
          "summary": "Get oneOf schema"
        }
      },

--- a/tests/cases/simple/output/remove-optional-body.out
+++ b/tests/cases/simple/output/remove-optional-body.out
@@ -1,6 +1,6 @@
 --- remove-optional-body.json
 +++ patched
-@@ -296,16 +296,6 @@
+@@
        },
        "put": {
          "operationId": "update_item",

--- a/tests/cases/simple/output/remove-required-body.out
+++ b/tests/cases/simple/output/remove-required-body.out
@@ -1,6 +1,6 @@
 --- remove-required-body.json
 +++ patched
-@@ -277,16 +277,6 @@
+@@
      "/items": {
        "post": {
          "operationId": "create_item",

--- a/tests/cases/simple/output/remove-response-code.out
+++ b/tests/cases/simple/output/remove-response-code.out
@@ -1,6 +1,6 @@
 --- remove-response-code.json
 +++ patched
-@@ -440,9 +440,6 @@
+@@
        "get": {
          "operationId": "with_default",
          "responses": {

--- a/tests/cases/simple/output/remove-unnamed-operation.out
+++ b/tests/cases/simple/output/remove-unnamed-operation.out
@@ -1,6 +1,6 @@
 --- remove-unnamed-operation.json
 +++ patched
-@@ -426,16 +426,6 @@
+@@
          "summary": "Get typed properties"
        }
      },

--- a/tests/cases/simple/output/schema-kind-type-to-oneof.out
+++ b/tests/cases/simple/output/schema-kind-type-to-oneof.out
@@ -1,6 +1,6 @@
 --- schema-kind-type-to-oneof.json
 +++ patched
-@@ -135,12 +135,14 @@
+@@
          "$ref": "#/components/schemas/SubType"
        },
        "SubType": {

--- a/tests/cases/simple/output/string-format-change.out
+++ b/tests/cases/simple/output/string-format-change.out
@@ -1,6 +1,6 @@
 --- string-format-change.json
 +++ patched
-@@ -50,6 +50,7 @@
+@@
          "properties": {
            "message": {
              "description": "The greeting message",

--- a/tests/cases/simple/output/type-indirection.out
+++ b/tests/cases/simple/output/type-indirection.out
@@ -1,6 +1,6 @@
 --- type-indirection.json
 +++ patched
-@@ -49,8 +49,7 @@
+@@
        "GreetingResponse": {
          "properties": {
            "message": {
@@ -10,7 +10,7 @@
            },
            "not_a_number": {
              "not": {
-@@ -90,6 +89,13 @@
+@@
          ],
          "type": "object"
        },

--- a/tests/cases/simple/output/type-rename.out
+++ b/tests/cases/simple/output/type-rename.out
@@ -1,6 +1,6 @@
 --- type-rename.json
 +++ patched
-@@ -46,7 +46,7 @@
+@@
          ],
          "type": "object"
        },
@@ -9,7 +9,7 @@
          "properties": {
            "message": {
              "description": "The greeting message",
-@@ -264,7 +264,7 @@
+@@
              "content": {
                "application/json": {
                  "schema": {

--- a/tests/cases/simple/output/unhandled-add-prop.out
+++ b/tests/cases/simple/output/unhandled-add-prop.out
@@ -1,6 +1,6 @@
 --- unhandled-add-prop.json
 +++ patched
-@@ -57,6 +57,10 @@
+@@
                "type": "number"
              }
            },
@@ -11,7 +11,7 @@
            "via_allof": {
              "allOf": [
                {
-@@ -86,7 +90,8 @@
+@@
            }
          },
          "required": [

--- a/tests/cases/simple/output/wrapper-unchanged-with-type-change.out
+++ b/tests/cases/simple/output/wrapper-unchanged-with-type-change.out
@@ -1,6 +1,6 @@
 --- wrapper-unchanged-with-type-change.json
 +++ patched
-@@ -137,7 +137,7 @@
+@@
        "SubType": {
          "properties": {
            "value": {

--- a/tests/test_changes.rs
+++ b/tests/test_changes.rs
@@ -48,7 +48,7 @@ fn test_change() {
                         let diff = TextDiff::from_lines(&base_pretty, &patched_pretty);
                         let patch_name = patch_entry.file_name();
 
-                        // Format theq unified diff manually, replacing `@@ -N,M
+                        // Format the unified diff manually, replacing `@@ -N,M
                         // +N,M @@` hunk headers with bare `@@` to avoid churn
                         // when base.json changes shift line positions.
                         let mut out = String::new();

--- a/tests/test_changes.rs
+++ b/tests/test_changes.rs
@@ -1,5 +1,7 @@
 // Copyright 2025 Oxide Computer Company
 
+use std::fmt::Write;
+
 use drift::compare;
 use similar::TextDiff;
 
@@ -39,19 +41,31 @@ fn test_change() {
                     json_patch::patch(&mut patched, &patch_value).unwrap();
 
                     let udiff = {
-                        // Suppress the observation regarding the lack of a
-                        // terminating newline.
                         let mut base_pretty = serde_json::to_string_pretty(&base_value).unwrap();
                         base_pretty.push('\n');
                         let mut patched_pretty = serde_json::to_string_pretty(&patched).unwrap();
                         patched_pretty.push('\n');
                         let diff = TextDiff::from_lines(&base_pretty, &patched_pretty);
-                        diff.unified_diff()
-                            .header(
-                                patch_entry.file_name().to_string_lossy().as_ref(),
-                                "patched",
-                            )
-                            .to_string()
+                        let patch_name = patch_entry.file_name();
+
+                        // Format theq unified diff manually, replacing `@@ -N,M
+                        // +N,M @@` hunk headers with bare `@@` to avoid churn
+                        // when base.json changes shift line positions.
+                        let mut out = String::new();
+                        let mut first = true;
+                        for hunk in diff.unified_diff().iter_hunks() {
+                            if first {
+                                writeln!(out, "--- {}", patch_name.to_string_lossy()).unwrap();
+                                writeln!(out, "+++ patched").unwrap();
+                                first = false;
+                            }
+                            writeln!(out, "@@").unwrap();
+                            for change in hunk.iter_changes() {
+                                write!(out, "{}{}", change.tag(), change.to_string_lossy())
+                                    .unwrap();
+                            }
+                        }
+                        out
                     };
 
                     let result =

--- a/tests/test_changes.rs
+++ b/tests/test_changes.rs
@@ -1,4 +1,4 @@
-// Copyright 2025 Oxide Computer Company
+// Copyright 2026 Oxide Computer Company
 
 use std::fmt::Write;
 


### PR DESCRIPTION
Whenever `base.json` changes we see a lot of unhelpful churn in these output files. Removing line numbers should lower the amount of churn.

The cost of this change is that it can become hard to tell what part of the file changed, since a lot of JSON looks identical. But hopefully looking at the patch files (the `.json`s in `tests/cases/simple/patch`) should provide the right guidance.
